### PR TITLE
[MSHARED-930] Fix SimpleResourceInclusionScanner.getIncludedSources() returns wrong…

### DIFF
--- a/src/main/java/org/apache/maven/shared/io/scan/SimpleResourceInclusionScanner.java
+++ b/src/main/java/org/apache/maven/shared/io/scan/SimpleResourceInclusionScanner.java
@@ -21,6 +21,7 @@ package org.apache.maven.shared.io.scan;
 
 import java.io.File;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -59,6 +60,13 @@ public class SimpleResourceInclusionScanner
             return Collections.<String>emptySet();
         }
 
-        return Collections.singleton( scanForSources( sourceDir, sourceIncludes, sourceExcludes ) );
+        Set<File> matchingSources = new HashSet<File>();
+        String[] sourcePaths = scanForSources( sourceDir, sourceIncludes, sourceExcludes );
+
+        for ( int i = 0; i < sourcePaths.length; i++ )
+        {
+            matchingSources.add( new File( sourceDir, sourcePaths[i] ) );
+        }
+        return matchingSources;
     }
 }

--- a/src/test/java/org/apache/maven/shared/io/scan/SimpleResourceInclusionScannerTest.java
+++ b/src/test/java/org/apache/maven/shared/io/scan/SimpleResourceInclusionScannerTest.java
@@ -1,0 +1,57 @@
+package org.apache.maven.shared.io.scan;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.shared.io.scan.mapping.SuffixMapping;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author dengliming
+ */
+public class SimpleResourceInclusionScannerTest {
+
+    @Test
+    public void testGetIncludedSources() throws IOException, InclusionScanException
+    {
+        File baseDir = new File("path/to/file" );
+        baseDir.deleteOnExit();
+        baseDir.mkdirs();
+        File f = File.createTempFile( "source1.", ".test", baseDir );
+
+        Set<String> sourceIncludes = new HashSet<String>();
+        sourceIncludes.add( "**/*" + f.getName() );
+        Set<String> sourceExcludes = new HashSet<String>();
+        SimpleResourceInclusionScanner simpleResourceInclusionScanner = new SimpleResourceInclusionScanner( sourceIncludes, sourceExcludes );
+        Set<String> targets = new HashSet<String>();
+        targets.add( ".class" );
+        simpleResourceInclusionScanner.addSourceMapping(new SuffixMapping( ".java", targets ));
+        Set<File> results = simpleResourceInclusionScanner.getIncludedSources( baseDir, baseDir );
+        assertTrue( results.size() > 0 );
+        assertEquals( f.getName(), results.iterator().next().getName() );
+    }
+}


### PR DESCRIPTION
[https://issues.apache.org/jira/browse/MSHARED-930](https://issues.apache.org/jira/browse/MSHARED-930)