### PR TITLE
[SECURITY] Fix Temporary File Information Disclosure Vulnerability


### DIFF
--- a/src/main/java/org/apache/maven/shared/io/download/DefaultDownloadManager.java
+++ b/src/main/java/org/apache/maven/shared/io/download/DefaultDownloadManager.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -121,7 +122,7 @@ public class DefaultDownloadManager
         try
         {
             // create the landing file in /tmp for the downloaded source archive
-            downloaded = File.createTempFile( "download-", null );
+            downloaded = Files.createTempFile( "download-", null ).toFile();
 
             // delete when the JVM exits, to avoid polluting the temp dir...
             downloaded.deleteOnExit();

--- a/src/main/java/org/apache/maven/shared/io/location/URLLocation.java
+++ b/src/main/java/org/apache/maven/shared/io/location/URLLocation.java
@@ -22,6 +22,7 @@ package org.apache.maven.shared.io.location;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.file.Files;
 
 import org.apache.maven.shared.utils.io.FileUtils;
 
@@ -66,7 +67,7 @@ public class URLLocation
         // TODO: Log this in the debug log-level...
         if ( unsafeGetFile() == null )
         {
-            File tempFile = File.createTempFile( tempFilePrefix, tempFileSuffix );
+            File tempFile = Files.createTempFile( tempFilePrefix, tempFileSuffix ).toFile();
 
             if ( tempFileDeleteOnExit )
             {

--- a/src/test/java/org/apache/maven/shared/io/download/DefaultDownloadManagerTest.java
+++ b/src/test/java/org/apache/maven/shared/io/download/DefaultDownloadManagerTest.java
@@ -29,6 +29,7 @@ import static org.easymock.EasyMock.verify;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Collections;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;
@@ -108,7 +109,7 @@ public class DefaultDownloadManagerTest
     public void testShouldDownloadFromTempFileWithNoTransferListeners()
         throws IOException, DownloadFailedException
     {
-        File tempFile = File.createTempFile( "download-source", "test" );
+        File tempFile = Files.createTempFile( "download-source", "test" ).toFile();
         tempFile.deleteOnExit();
 
         setupDefaultMockConfiguration();
@@ -125,7 +126,7 @@ public class DefaultDownloadManagerTest
     public void testShouldDownloadFromTempFileTwiceAndUseCache()
         throws IOException, DownloadFailedException
     {
-        File tempFile = File.createTempFile( "download-source", "test" );
+        File tempFile = Files.createTempFile( "download-source", "test" ).toFile();
         tempFile.deleteOnExit();
 
         setupDefaultMockConfiguration();
@@ -150,7 +151,7 @@ public class DefaultDownloadManagerTest
     public void testShouldDownloadFromTempFileWithOneTransferListener()
         throws IOException, DownloadFailedException
     {
-        File tempFile = File.createTempFile( "download-source", "test" );
+        File tempFile = Files.createTempFile( "download-source", "test" ).toFile();
         tempFile.deleteOnExit();
 
         setupDefaultMockConfiguration();
@@ -174,7 +175,7 @@ public class DefaultDownloadManagerTest
     public void testShouldFailToDownloadWhenWagonProtocolNotFound()
         throws IOException
     {
-        File tempFile = File.createTempFile( "download-source", "test" );
+        File tempFile = Files.createTempFile( "download-source", "test" ).toFile();
         tempFile.deleteOnExit();
 
         setupMocksWithWagonManagerGetException( new UnsupportedProtocolException( "not supported" ) );
@@ -200,7 +201,7 @@ public class DefaultDownloadManagerTest
     public void testShouldFailToDownloadWhenWagonConnectThrowsConnectionException()
         throws IOException
     {
-        File tempFile = File.createTempFile( "download-source", "test" );
+        File tempFile = Files.createTempFile( "download-source", "test" ).toFile();
         tempFile.deleteOnExit();
 
         setupMocksWithWagonConnectionException( new ConnectionException( "connect error" ) );
@@ -226,7 +227,7 @@ public class DefaultDownloadManagerTest
     public void testShouldFailToDownloadWhenWagonConnectThrowsAuthenticationException()
         throws IOException
     {
-        File tempFile = File.createTempFile( "download-source", "test" );
+        File tempFile = Files.createTempFile( "download-source", "test" ).toFile();
         tempFile.deleteOnExit();
 
         setupMocksWithWagonConnectionException( new AuthenticationException( "bad credentials" ) );
@@ -252,7 +253,7 @@ public class DefaultDownloadManagerTest
     public void testShouldFailToDownloadWhenWagonGetThrowsTransferFailedException()
         throws IOException
     {
-        File tempFile = File.createTempFile( "download-source", "test" );
+        File tempFile = Files.createTempFile( "download-source", "test" ).toFile();
         tempFile.deleteOnExit();
 
         setupMocksWithWagonGetException( new TransferFailedException( "bad transfer" ) );
@@ -278,7 +279,7 @@ public class DefaultDownloadManagerTest
     public void testShouldFailToDownloadWhenWagonGetThrowsResourceDoesNotExistException()
         throws IOException
     {
-        File tempFile = File.createTempFile( "download-source", "test" );
+        File tempFile = Files.createTempFile( "download-source", "test" ).toFile();
         tempFile.deleteOnExit();
 
         setupMocksWithWagonGetException( new ResourceDoesNotExistException( "bad resource" ) );
@@ -304,7 +305,7 @@ public class DefaultDownloadManagerTest
     public void testShouldFailToDownloadWhenWagonGetThrowsAuthorizationException()
         throws IOException
     {
-        File tempFile = File.createTempFile( "download-source", "test" );
+        File tempFile = Files.createTempFile( "download-source", "test" ).toFile();
         tempFile.deleteOnExit();
 
         setupMocksWithWagonGetException( new AuthorizationException( "bad transfer" ) );
@@ -330,7 +331,7 @@ public class DefaultDownloadManagerTest
     public void testShouldFailToDownloadWhenWagonDisconnectThrowsConnectionException()
         throws IOException, DownloadFailedException
     {
-        File tempFile = File.createTempFile( "download-source", "test" );
+        File tempFile = Files.createTempFile( "download-source", "test" ).toFile();
         tempFile.deleteOnExit();
 
         setupMocksWithWagonDisconnectException( new ConnectionException( "not connected" ) );

--- a/src/test/java/org/apache/maven/shared/io/location/ArtifactLocationTest.java
+++ b/src/test/java/org/apache/maven/shared/io/location/ArtifactLocationTest.java
@@ -21,6 +21,7 @@ package org.apache.maven.shared.io.location;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 
 import junit.framework.TestCase;
 
@@ -37,7 +38,7 @@ public class ArtifactLocationTest
     public void testShouldConstructFromTempFileSpecification()
         throws IOException
     {
-        File f = File.createTempFile( "artifact-location.", ".test" );
+        File f = Files.createTempFile( "artifact-location.", ".test" ).toFile();
         f.deleteOnExit();
 
         Artifact a = new DefaultArtifact( "group", "artifact", VersionRange.createFromVersion( "1" ), null, "jar",
@@ -53,7 +54,7 @@ public class ArtifactLocationTest
     public void testShouldRead()
         throws IOException
     {
-        File f = File.createTempFile( "url-location.", ".test" );
+        File f = Files.createTempFile( "url-location.", ".test" ).toFile();
         f.deleteOnExit();
 
         String testStr = "This is a test";

--- a/src/test/java/org/apache/maven/shared/io/location/ArtifactLocatorStrategyTest.java
+++ b/src/test/java/org/apache/maven/shared/io/location/ArtifactLocatorStrategyTest.java
@@ -21,6 +21,7 @@ package org.apache.maven.shared.io.location;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Collections;
 
 import junit.framework.TestCase;
@@ -106,7 +107,7 @@ public class ArtifactLocatorStrategyTest
     public void testShouldResolveSpecWithThreeTokensUsingDefaultType()
         throws IOException
     {
-        File tempFile = File.createTempFile( "artifact-location.", ".temp" );
+        File tempFile = Files.createTempFile( "artifact-location.", ".temp" ).toFile();
         tempFile.deleteOnExit();
 
         Artifact artifact = createMock( Artifact.class );
@@ -150,7 +151,7 @@ public class ArtifactLocatorStrategyTest
     public void testShouldResolveSpecWithThreeTokensUsingCustomizedDefaultType()
         throws IOException
     {
-        File tempFile = File.createTempFile( "artifact-location.", ".temp" );
+        File tempFile = Files.createTempFile( "artifact-location.", ".temp" ).toFile();
         tempFile.deleteOnExit();
 
         Artifact artifact = createMock( Artifact.class );
@@ -194,7 +195,7 @@ public class ArtifactLocatorStrategyTest
     public void testShouldResolveSpecWithFourTokens()
         throws IOException
     {
-        File tempFile = File.createTempFile( "artifact-location.", ".temp" );
+        File tempFile = Files.createTempFile( "artifact-location.", ".temp" ).toFile();
         tempFile.deleteOnExit();
 
         Artifact artifact = createMock( Artifact.class );
@@ -238,7 +239,7 @@ public class ArtifactLocatorStrategyTest
     public void testShouldResolveSpecWithFiveTokens()
         throws IOException
     {
-        File tempFile = File.createTempFile( "artifact-location.", ".temp" );
+        File tempFile = Files.createTempFile( "artifact-location.", ".temp" ).toFile();
         tempFile.deleteOnExit();
 
         Artifact artifact = createMock( Artifact.class );
@@ -283,7 +284,7 @@ public class ArtifactLocatorStrategyTest
     public void testShouldResolveSpecWithFiveTokensAndEmptyTypeToken()
         throws IOException
     {
-        File tempFile = File.createTempFile( "artifact-location.", ".temp" );
+        File tempFile = Files.createTempFile( "artifact-location.", ".temp" ).toFile();
         tempFile.deleteOnExit();
 
         Artifact artifact = createMock( Artifact.class );
@@ -328,7 +329,7 @@ public class ArtifactLocatorStrategyTest
     public void testShouldResolveSpecWithMoreThanFiveTokens()
         throws IOException
     {
-        File tempFile = File.createTempFile( "artifact-location.", ".temp" );
+        File tempFile = Files.createTempFile( "artifact-location.", ".temp" ).toFile();
         tempFile.deleteOnExit();
 
         Artifact artifact = createMock( Artifact.class );

--- a/src/test/java/org/apache/maven/shared/io/location/FileLocationTest.java
+++ b/src/test/java/org/apache/maven/shared/io/location/FileLocationTest.java
@@ -28,6 +28,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.nio.file.Files;
 
 import junit.framework.TestCase;
 
@@ -37,7 +38,7 @@ public class FileLocationTest
 
     public void testShouldConstructWithFileThenRetrieveSameFile() throws IOException
     {
-        File file = File.createTempFile( "test.", ".file-location" );
+        File file = Files.createTempFile( "test.", ".file-location" ).toFile();
         file.deleteOnExit();
 
         FileLocation location = new FileLocation( file, file.getAbsolutePath() );
@@ -48,7 +49,7 @@ public class FileLocationTest
 
     public void testShouldReadFileContentsUsingByteBuffer() throws IOException
     {
-        File file = File.createTempFile( "test.", ".file-location" );
+        File file = Files.createTempFile( "test.", ".file-location" ).toFile();
         file.deleteOnExit();
 
         String testStr = "This is a test";
@@ -67,7 +68,7 @@ public class FileLocationTest
 
     public void testShouldReadFileContentsUsingStream() throws IOException
     {
-        File file = File.createTempFile( "test.", ".file-location" );
+        File file = Files.createTempFile( "test.", ".file-location" ).toFile();
         file.deleteOnExit();
 
         String testStr = "This is a test";
@@ -88,7 +89,7 @@ public class FileLocationTest
 
     public void testShouldReadFileContentsUsingByteArray() throws IOException
     {
-        File file = File.createTempFile( "test.", ".file-location" );
+        File file = Files.createTempFile( "test.", ".file-location" ).toFile();
         file.deleteOnExit();
 
         String testStr = "This is a test";
@@ -107,7 +108,7 @@ public class FileLocationTest
 
     public void testShouldReadThenClose() throws IOException
     {
-        File file = File.createTempFile( "test.", ".file-location" );
+        File file = Files.createTempFile( "test.", ".file-location" ).toFile();
         file.deleteOnExit();
 
         String testStr = "This is a test";
@@ -128,7 +129,7 @@ public class FileLocationTest
 
     public void testShouldOpenThenFailToSetFile() throws IOException
     {
-        File file = File.createTempFile( "test.", ".file-location" );
+        File file = Files.createTempFile( "test.", ".file-location" ).toFile();
         file.deleteOnExit();
 
         TestFileLocation location = new TestFileLocation( file.getAbsolutePath() );
@@ -148,7 +149,7 @@ public class FileLocationTest
 
     public void testShouldConstructWithoutFileThenSetFileThenOpen() throws IOException
     {
-        File file = File.createTempFile( "test.", ".file-location" );
+        File file = Files.createTempFile( "test.", ".file-location" ).toFile();
         file.deleteOnExit();
 
         TestFileLocation location = new TestFileLocation( file.getAbsolutePath() );
@@ -159,7 +160,7 @@ public class FileLocationTest
 
     public void testShouldConstructWithLocationThenRetrieveEquivalentFile() throws IOException
     {
-        File file = File.createTempFile( "test.", ".file-location" );
+        File file = Files.createTempFile( "test.", ".file-location" ).toFile();
         file.deleteOnExit();
 
         Location location = new TestFileLocation( file.getAbsolutePath() );

--- a/src/test/java/org/apache/maven/shared/io/location/FileLocatorStrategyTest.java
+++ b/src/test/java/org/apache/maven/shared/io/location/FileLocatorStrategyTest.java
@@ -21,6 +21,7 @@ package org.apache.maven.shared.io.location;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 
 import org.apache.maven.shared.io.logging.DefaultMessageHolder;
 import org.apache.maven.shared.io.logging.MessageHolder;
@@ -33,7 +34,7 @@ public class FileLocatorStrategyTest
 
     public void testShouldResolveExistingTempFileLocation() throws IOException
     {
-        File f = File.createTempFile( "file-locator.", ".test" );
+        File f = Files.createTempFile( "file-locator.", ".test" ).toFile();
         f.deleteOnExit();
 
         FileLocatorStrategy fls = new FileLocatorStrategy();
@@ -51,7 +52,7 @@ public class FileLocatorStrategyTest
 
     public void testShouldFailToResolveNonExistentFileLocation() throws IOException
     {
-        File f = File.createTempFile( "file-locator.", ".test" );
+        File f = Files.createTempFile( "file-locator.", ".test" ).toFile();
         f.delete();
 
         FileLocatorStrategy fls = new FileLocatorStrategy();

--- a/src/test/java/org/apache/maven/shared/io/location/URLLocationTest.java
+++ b/src/test/java/org/apache/maven/shared/io/location/URLLocationTest.java
@@ -22,6 +22,7 @@ package org.apache.maven.shared.io.location;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.file.Files;
 
 import org.apache.commons.io.FileUtils;
 
@@ -33,7 +34,7 @@ public class URLLocationTest
 
     public void testShouldConstructFromUrlAndTempFileSpecifications() throws IOException
     {
-        File f = File.createTempFile( "url-location.", ".test" );
+        File f = Files.createTempFile( "url-location.", ".test" ).toFile();
         f.deleteOnExit();
 
         URL url = f.toURL();
@@ -43,7 +44,7 @@ public class URLLocationTest
 
     public void testShouldTransferFromTempFile() throws IOException
     {
-        File f = File.createTempFile( "url-location.", ".test" );
+        File f = Files.createTempFile( "url-location.", ".test" ).toFile();
         f.deleteOnExit();
 
         URL url = f.toURL();
@@ -56,7 +57,7 @@ public class URLLocationTest
 
     public void testShouldTransferFromTempFileThenRead() throws IOException
     {
-        File f = File.createTempFile( "url-location.", ".test" );
+        File f = Files.createTempFile( "url-location.", ".test" ).toFile();
         f.deleteOnExit();
 
         String testStr = "This is a test";

--- a/src/test/java/org/apache/maven/shared/io/location/URLLocatorStrategyTest.java
+++ b/src/test/java/org/apache/maven/shared/io/location/URLLocatorStrategyTest.java
@@ -21,6 +21,7 @@ package org.apache.maven.shared.io.location;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 
 import junit.framework.TestCase;
 
@@ -54,7 +55,7 @@ public class URLLocatorStrategyTest
 
     public void testShouldResolveUrlForTempFile() throws IOException
     {
-        File tempFile = File.createTempFile( "prefix.", ".suffix" );
+        File tempFile = Files.createTempFile( "prefix.", ".suffix" ).toFile();
         tempFile.deleteOnExit();
 
         String testStr = "This is a test.";

--- a/src/test/java/org/apache/maven/shared/io/scan/SimpleResourceInclusionScannerTest.java
+++ b/src/test/java/org/apache/maven/shared/io/scan/SimpleResourceInclusionScannerTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -41,7 +42,7 @@ public class SimpleResourceInclusionScannerTest {
         File baseDir = new File("target" );
         baseDir.deleteOnExit();
         baseDir.mkdirs();
-        File f = File.createTempFile( "source1.", ".test", baseDir );
+        File f = Files.createTempFile( baseDir.toPath(), "source1.", ".test" ).toFile();
 
         Set<String> sourceIncludes = new HashSet<>();
         sourceIncludes.add( "**/*" + f.getName() );


### PR DESCRIPTION

# Security Vulnerability Fix

This pull request fixes a Temporary File Information Disclosure Vulnerability, which existed in this project.

## Preamble

The system temporary directory is shared between all users on most unix-like systems (not MacOS, or Windows). Thus, code interacting with the system temporary directory must be careful about file interactions in this directory, and must ensure that the correct file posix permissions are set.

This PR was generated because a call to `File.createTempFile(..)` was detected in this repository in a way that makes this project vulnerable to local information disclosure.
With the default uname configuration, `File.createTempFile(..)` creates a file with the permissions `-rw-r--r--`. This means that any other user on the system can read the contents of this file.

### Impact

Information in this file is visible to other local users, allowing a malicious actor co-resident on the same machine to view potentially sensitive files.

#### Other Examples

 - [CVE-2020-15250](https://github.com/advisories/GHSA-269g-pwp5-87pp) - junit-team/junit
 - [CVE-2021-21364](https://github.com/advisories/GHSA-hpv8-9rq5-hq7w) - swagger-api/swagger-codegen
 - [CVE-2022-24823](https://github.com/advisories/GHSA-5mcr-gq6c-3hq2) - netty/netty
 - [CVE-2022-24823](https://github.com/advisories/GHSA-269q-hmxg-m83q) - netty/netty

# The Fix

The fix has been to convert the logic above to use the following API that was introduced in Java 1.7.

```java
File tmpDir = Files.createTempFile("temp dir").toFile();
```

The API both creates the file securely, ie. with a random, non-conflicting name, with file permissions that only allow the currently executing user to read or write the contents of this file.
By default, `Files.createTempFile("temp dir")` will create a file with the permissions `-rw-------`, which only allows the user that created the file to view/write the file contents.

# :arrow_right: Vulnerability Disclosure :arrow_left:

:wave: Vulnerability disclosure is a super important part of the vulnerability handling process and should not be skipped! This may be completely new to you, and that's okay, I'm here to assist!

First question, do we need to perform vulnerability disclosure? It depends!

 1. Is the vulnerable code only in tests or example code? No disclosure required!
 2. Is the vulnerable code in code shipped to your end users? Vulnerability disclosure is probably required!

## Vulnerability Disclosure How-To

You have a few options options to perform vulnerability disclosure. However, I'd like to suggest the following 2 options:

 1. Request a CVE number from GitHub by creating a repository-level [GitHub Security Advisory](https://docs.github.com/en/code-security/repository-security-advisories/creating-a-repository-security-advisory). This has the advantage that, if you provide sufficient information, GitHub will automatically generate Dependabot alerts for your downstream consumers, resolving this vulnerability more quickly.
 2. Reach out to the team at Snyk to assist with CVE issuance. They can be reached at the [Snyk's Disclosure Email](mailto:report@snyk.io).

## Detecting this and Future Vulnerabilities

This vulnerability was automatically detected by GitHub's CodeQL using this [CodeQL Query](https://codeql.github.com/codeql-query-help/java/java-local-temp-file-or-directory-information-disclosure/).

You can automatically detect future vulnerabilities like this by enabling the free (for open-source) [GitHub Action](https://github.com/github/codeql-action).

I'm not an employee of GitHub, I'm simply an open-source security researcher.

## Source

This contribution was automatically generated with an [OpenRewrite](https://github.com/openrewrite/rewrite) [refactoring recipe](https://docs.openrewrite.org/), which was lovingly hand crafted to bring this security fix to your repository.

The source code that generated this PR can be found here:
[SecureTempFileCreation](https://github.com/openrewrite/rewrite-java-security/blob/main/src/main/java/org/openrewrite/java/security/SecureTempFileCreation.java)

## Opting-Out

If you'd like to opt-out of future automated security vulnerability fixes like this, please consider adding a file called
`.github/GH-ROBOTS.txt` to your repository with the line:

```
User-agent: JLLeitschuh/security-research
Disallow: *
```

This bot will respect the [ROBOTS.txt](https://moz.com/learn/seo/robotstxt) format for future contributions.

Alternatively, if this project is no longer actively maintained, consider [archiving](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-archiving-repositories) the repository.

## CLA Requirements

_This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions._

It is unlikely that I'll be able to directly sign CLAs. However, all contributed commits are already automatically signed-off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin
> (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
>
> \- [Git Commit Signoff documentation](https://developercertificate.org/)

If signing your organization's CLA is a strict-requirement for merging this contribution, please feel free to close this PR.

## Sponsorship & Support

This contribution is sponsored by HUMAN Security Inc. and the new Dan Kaminsky Fellowship, a fellowship created to celebrate Dan's memory and legacy by funding open-source work that makes the world a better (and more secure) place.

This PR was generated by [Moderne](https://www.moderne.io/), a free-for-open source SaaS offering that uses format-preserving AST transformations to fix bugs, standardize code style, apply best practices, migrate library versions, and fix common security vulnerabilities at scale.

## Tracking

All PR's generated as part of this fix are tracked here: https://github.com/JLLeitschuh/security-research/issues/18
