### PR TITLE
[MSHARED-1468] Upgrade parent POM to version 43

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.maven.shared</groupId>
     <artifactId>maven-shared-components</artifactId>
-    <version>39</version>
+    <version>43</version>
     <relativePath />
   </parent>
 
@@ -127,6 +127,11 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-xml</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MSHARED-1468

The reactor build didn't work (support-and-care/maven-support-and-care#77). 
Additionally, it was necessary to add a dependency to a current Plexus-XML.