### PR TITLE
fix #84: guard against null wagonManager and null getWagon()

### DIFF
--- a/src/main/java/org/apache/maven/shared/io/download/DefaultDownloadManager.java
+++ b/src/main/java/org/apache/maven/shared/io/download/DefaultDownloadManager.java
@@ -58,7 +58,12 @@ public class DefaultDownloadManager implements DownloadManager {
 
     /**
      * Create an instance of the {@code DefaultDownloadManager}.
+     *
+     * @deprecated The no-arg constructor creates a DefaultDownloadManager that is completely non-functional and
+     *             cannot download anything without a {@link WagonManager}. Use
+     *             {@link #DefaultDownloadManager(WagonManager)} instead.
      */
+    @Deprecated
     public DefaultDownloadManager() {}
 
     /**

--- a/src/main/java/org/apache/maven/shared/io/download/DefaultDownloadManager.java
+++ b/src/main/java/org/apache/maven/shared/io/download/DefaultDownloadManager.java
@@ -91,6 +91,10 @@ public class DefaultDownloadManager implements DownloadManager {
             throw new DownloadFailedException(url, "Download failed due to invalid URL.", e);
         }
 
+        if (wagonManager == null) {
+            throw new DownloadFailedException(url, "WagonManager not set in DefaultDownloadManager.");
+        }
+
         Wagon wagon = null;
 
         // Retrieve the correct Wagon instance used to download the remote archive
@@ -98,6 +102,10 @@ public class DefaultDownloadManager implements DownloadManager {
             wagon = wagonManager.getWagon(sourceUrl.getProtocol());
         } catch (UnsupportedProtocolException e) {
             throw new DownloadFailedException(url, "Download failed", e);
+        }
+
+        if (wagon == null) {
+            throw new DownloadFailedException(url, "No wagon available for protocol: " + sourceUrl.getProtocol());
         }
 
         messageHolder.addMessage("Using wagon: " + wagon + " to download: " + url);

--- a/src/test/java/org/apache/maven/shared/io/download/DefaultDownloadManagerTest.java
+++ b/src/test/java/org/apache/maven/shared/io/download/DefaultDownloadManagerTest.java
@@ -72,9 +72,9 @@ class DefaultDownloadManagerTest {
 
     @Test
     void shouldFailToDownloadWhenWagonManagerIsNull() {
-        DefaultDownloadManager mgr = new DefaultDownloadManager();
+        DefaultDownloadManager downloadManager = new DefaultDownloadManager();
         try {
-            mgr.download("http://example.com/file.txt", new DefaultMessageHolder());
+            downloadManager.download("http://example.com/file.txt", new DefaultMessageHolder());
             fail("Should have thrown DownloadFailedException.");
         } catch (DownloadFailedException e) {
             assertTrue(e.getMessage().contains("WagonManager not set"));
@@ -86,9 +86,9 @@ class DefaultDownloadManagerTest {
         expect(wagonManager.getWagon("file")).andReturn(null);
         replay(wagonManager);
 
-        DefaultDownloadManager mgr = new DefaultDownloadManager(wagonManager);
+        DefaultDownloadManager downloadManager = new DefaultDownloadManager(wagonManager);
         try {
-            mgr.download(
+            downloadManager.download(
                     Files.createTempFile("download-source", "test")
                             .toFile()
                             .toURI()

--- a/src/test/java/org/apache/maven/shared/io/download/DefaultDownloadManagerTest.java
+++ b/src/test/java/org/apache/maven/shared/io/download/DefaultDownloadManagerTest.java
@@ -71,6 +71,38 @@ class DefaultDownloadManagerTest {
     }
 
     @Test
+    void shouldFailToDownloadWhenWagonManagerIsNull() {
+        DefaultDownloadManager mgr = new DefaultDownloadManager();
+        try {
+            mgr.download("http://example.com/file.txt", new DefaultMessageHolder());
+            fail("Should have thrown DownloadFailedException.");
+        } catch (DownloadFailedException e) {
+            assertTrue(e.getMessage().contains("WagonManager not set"));
+        }
+    }
+
+    @Test
+    void shouldFailToDownloadWhenGetWagonReturnsNull() throws Exception {
+        expect(wagonManager.getWagon("file")).andReturn(null);
+        replay(wagonManager);
+
+        DefaultDownloadManager mgr = new DefaultDownloadManager(wagonManager);
+        try {
+            mgr.download(
+                    Files.createTempFile("download-source", "test")
+                            .toFile()
+                            .toURI()
+                            .toASCIIString(),
+                    new DefaultMessageHolder());
+            fail("Should have thrown DownloadFailedException.");
+        } catch (DownloadFailedException e) {
+            assertTrue(e.getMessage().contains("No wagon available"));
+        }
+
+        verify(wagonManager);
+    }
+
+    @Test
     void shouldConstructWithWagonManager() {
         replay(wagonManager);
 


### PR DESCRIPTION
Check wagonManager for null at start of download() and check wagon for null after getWagon() to prevent NPEs.

Fixes #84