### PR TITLE
fix #86: null stream and channel after close() to allow re-open

### DIFF
--- a/src/main/java/org/apache/maven/shared/io/location/FileLocation.java
+++ b/src/main/java/org/apache/maven/shared/io/location/FileLocation.java
@@ -68,6 +68,9 @@ public class FileLocation implements Location {
                 // swallow it.
             }
         }
+
+        channel = null;
+        stream = null;
     }
 
     /** {@inheritDoc} */

--- a/src/test/java/org/apache/maven/shared/io/location/FileLocationTest.java
+++ b/src/test/java/org/apache/maven/shared/io/location/FileLocationTest.java
@@ -127,6 +127,31 @@ class FileLocationTest {
     }
 
     @Test
+    void shouldReopenAfterClose() throws Exception {
+        File file = Files.createTempFile("test.", ".file-location").toFile();
+        file.deleteOnExit();
+
+        String testStr = "This is a test";
+
+        FileUtils.writeStringToFile(file, testStr, "US-ASCII");
+
+        FileLocation location = new FileLocation(file, file.getAbsolutePath());
+
+        location.open();
+        byte[] buffer = new byte[testStr.length()];
+        location.read(buffer);
+        assertEquals(testStr, new String(buffer, StandardCharsets.US_ASCII));
+        location.close();
+
+        // read again after close should re-open
+        location.open();
+        buffer = new byte[testStr.length()];
+        location.read(buffer);
+        assertEquals(testStr, new String(buffer, StandardCharsets.US_ASCII));
+        location.close();
+    }
+
+    @Test
     void shouldOpenThenFailToSetFile() throws Exception {
         File file = Files.createTempFile("test.", ".file-location").toFile();
         file.deleteOnExit();


### PR DESCRIPTION
After close(), set channel and stream to null so that open() can re-initialize them on subsequent read calls.

Fixes #86