### PR TITLE
fix #87: null-check getTargetFiles() return value

### DIFF
--- a/src/main/java/org/apache/maven/shared/io/scan/StaleResourceScanner.java
+++ b/src/main/java/org/apache/maven/shared/io/scan/StaleResourceScanner.java
@@ -93,6 +93,10 @@ public class StaleResourceScanner extends AbstractResourceInclusionScanner {
             for (SourceMapping mapping : srcMappings) {
                 Set<File> targetFiles = mapping.getTargetFiles(targetDir, path);
 
+                if (targetFiles == null) {
+                    continue;
+                }
+
                 // never include files that don't have corresponding target mappings.
                 // the targets don't have to exist on the filesystem, but the
                 // mappers must tell us to look for them.

--- a/src/test/java/org/apache/maven/shared/io/scan/StaleResourceScannerTest.java
+++ b/src/test/java/org/apache/maven/shared/io/scan/StaleResourceScannerTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.shared.io.scan;
+
+import java.io.File;
+import java.util.Set;
+
+import org.apache.maven.shared.io.scan.mapping.SourceMapping;
+import org.junit.jupiter.api.Test;
+
+class StaleResourceScannerTest {
+
+    @Test
+    void shouldNotNpeWhenGetTargetFilesReturnsNull() throws Exception {
+        StaleResourceScanner scanner = new StaleResourceScanner();
+        scanner.addSourceMapping(new SourceMapping() {
+            public Set<File> getTargetFiles(File targetDir, String source) {
+                return null;
+            }
+        });
+
+        File sourceDir = new File("src/test");
+        File targetDir = new File("target");
+        scanner.getIncludedSources(sourceDir, targetDir);
+    }
+}

--- a/src/test/java/org/apache/maven/shared/io/scan/StaleResourceScannerTest.java
+++ b/src/test/java/org/apache/maven/shared/io/scan/StaleResourceScannerTest.java
@@ -19,10 +19,13 @@
 package org.apache.maven.shared.io.scan;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.util.Set;
 
 import org.apache.maven.shared.io.scan.mapping.SourceMapping;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 class StaleResourceScannerTest {
 
@@ -30,13 +33,18 @@ class StaleResourceScannerTest {
     void shouldNotNpeWhenGetTargetFilesReturnsNull() throws Exception {
         StaleResourceScanner scanner = new StaleResourceScanner();
         scanner.addSourceMapping(new SourceMapping() {
+            @Override
             public Set<File> getTargetFiles(File targetDir, String source) {
                 return null;
             }
         });
 
-        File sourceDir = new File("src/test");
-        File targetDir = new File("target");
-        scanner.getIncludedSources(sourceDir, targetDir);
+        File baseDir = new File("target");
+        baseDir.mkdirs();
+        File sourceDir = Files.createTempDirectory(baseDir.toPath(), "stale-scanner-src-").toFile();
+        File targetDir = Files.createTempDirectory(baseDir.toPath(), "stale-scanner-tgt-").toFile();
+        Files.createTempFile(sourceDir.toPath(), "source", ".txt");
+
+        assertDoesNotThrow(() -> scanner.getIncludedSources(sourceDir, targetDir));
     }
 }

--- a/src/test/java/org/apache/maven/shared/io/scan/StaleResourceScannerTest.java
+++ b/src/test/java/org/apache/maven/shared/io/scan/StaleResourceScannerTest.java
@@ -41,8 +41,10 @@ class StaleResourceScannerTest {
 
         File baseDir = new File("target");
         baseDir.mkdirs();
-        File sourceDir = Files.createTempDirectory(baseDir.toPath(), "stale-scanner-src-").toFile();
-        File targetDir = Files.createTempDirectory(baseDir.toPath(), "stale-scanner-tgt-").toFile();
+        File sourceDir = Files.createTempDirectory(baseDir.toPath(), "stale-scanner-src-")
+                .toFile();
+        File targetDir = Files.createTempDirectory(baseDir.toPath(), "stale-scanner-tgt-")
+                .toFile();
         Files.createTempFile(sourceDir.toPath(), "source", ".txt");
 
         assertDoesNotThrow(() -> scanner.getIncludedSources(sourceDir, targetDir));


### PR DESCRIPTION
Skip SourceMapping entries that return null from getTargetFiles() instead of throwing NPE.

Fixes #87