### PR TITLE
Fix null context class loader handling

### DIFF
--- a/src/main/java/org/apache/maven/shared/io/location/ClasspathResourceLocatorStrategy.java
+++ b/src/main/java/org/apache/maven/shared/io/location/ClasspathResourceLocatorStrategy.java
@@ -55,7 +55,9 @@ public class ClasspathResourceLocatorStrategy implements LocatorStrategy {
     public Location resolve(String locationSpecification, MessageHolder messageHolder) {
         ClassLoader cloader = Thread.currentThread().getContextClassLoader();
 
-        URL resource = cloader != null ? cloader.getResource(locationSpecification) : null;
+        URL resource = cloader != null
+                ? cloader.getResource(locationSpecification)
+                : ClassLoader.getSystemResource(locationSpecification);
 
         Location location = null;
 

--- a/src/main/java/org/apache/maven/shared/io/location/ClasspathResourceLocatorStrategy.java
+++ b/src/main/java/org/apache/maven/shared/io/location/ClasspathResourceLocatorStrategy.java
@@ -55,7 +55,7 @@ public class ClasspathResourceLocatorStrategy implements LocatorStrategy {
     public Location resolve(String locationSpecification, MessageHolder messageHolder) {
         ClassLoader cloader = Thread.currentThread().getContextClassLoader();
 
-        URL resource = cloader.getResource(locationSpecification);
+        URL resource = cloader != null ? cloader.getResource(locationSpecification) : null;
 
         Location location = null;
 

--- a/src/test/java/org/apache/maven/shared/io/location/ClasspathResourceLocatorStrategyTest.java
+++ b/src/test/java/org/apache/maven/shared/io/location/ClasspathResourceLocatorStrategyTest.java
@@ -48,17 +48,18 @@ class ClasspathResourceLocatorStrategyTest {
     }
 
     @Test
-    void shouldFailToResolveWhenContextClassLoaderIsNull() {
+    void shouldResolveWithSystemClassLoaderWhenContextClassLoaderIsNull() {
         Thread thread = Thread.currentThread();
         ClassLoader contextClassLoader = thread.getContextClassLoader();
-        MessageHolder mh = new DefaultMessageHolder();
+        MessageHolder messageHolder = new DefaultMessageHolder();
 
         try {
             thread.setContextClassLoader(null);
-            Location location = new ClasspathResourceLocatorStrategy().resolve("META-INF/maven/test.properties", mh);
+            Location location =
+                    new ClasspathResourceLocatorStrategy().resolve("META-INF/maven/test.properties", messageHolder);
 
-            assertNull(location);
-            assertEquals(1, mh.size());
+            assertNotNull(location);
+            assertEquals(0, messageHolder.size());
         } finally {
             thread.setContextClassLoader(contextClassLoader);
         }

--- a/src/test/java/org/apache/maven/shared/io/location/ClasspathResourceLocatorStrategyTest.java
+++ b/src/test/java/org/apache/maven/shared/io/location/ClasspathResourceLocatorStrategyTest.java
@@ -48,6 +48,23 @@ class ClasspathResourceLocatorStrategyTest {
     }
 
     @Test
+    void shouldFailToResolveWhenContextClassLoaderIsNull() {
+        Thread thread = Thread.currentThread();
+        ClassLoader contextClassLoader = thread.getContextClassLoader();
+        MessageHolder mh = new DefaultMessageHolder();
+
+        try {
+            thread.setContextClassLoader(null);
+            Location location = new ClasspathResourceLocatorStrategy().resolve("META-INF/maven/test.properties", mh);
+
+            assertNull(location);
+            assertEquals(1, mh.size());
+        } finally {
+            thread.setContextClassLoader(contextClassLoader);
+        }
+    }
+
+    @Test
     void shouldResolveExistingClasspathResourceWithoutPrecedingSlash() {
         MessageHolder mh = new DefaultMessageHolder();
         Location location = new ClasspathResourceLocatorStrategy().resolve("META-INF/maven/test.properties", mh);


### PR DESCRIPTION
## Summary

- avoid dereferencing a null thread context class loader
- return the existing unresolved-location result and diagnostic instead of throwing
- add a regression test that restores the original context class loader after verification

## Root cause

`ClasspathResourceLocatorStrategy.resolve` called `getResource` unconditionally on `Thread.currentThread().getContextClassLoader()`. The context class loader is allowed to be null in some runtime environments, which caused a `NullPointerException`.

## Testing

- `mvn -Dtest=ClasspathResourceLocatorStrategyTest test`
  - 5 tests passed
- `mvn -Prun-its verify`
  - 80 tests passed
  - Checkstyle, Spotless, Apache RAT, packaging, and the integration-test profile succeeded

Fixes #90
