### PR TITLE
Fix NullPointerException in SingleTargetMapping when source or suffix…

### DIFF
--- a/src/main/java/org/apache/maven/shared/io/scan/mapping/SingleTargetMapping.java
+++ b/src/main/java/org/apache/maven/shared/io/scan/mapping/SingleTargetMapping.java
@@ -47,6 +47,9 @@ public class SingleTargetMapping implements SourceMapping {
 
     /** {@inheritDoc} */
     public Set<File> getTargetFiles(File targetDir, String source) throws InclusionScanException {
+        if (source == null || sourceSuffix == null) {
+            return Collections.<File>emptySet();
+        }
         if (!source.endsWith(sourceSuffix)) {
             return Collections.<File>emptySet();
         }

--- a/src/test/java/org/apache/maven/shared/io/scan/mapping/SingleTargetMappingTest.java
+++ b/src/test/java/org/apache/maven/shared/io/scan/mapping/SingleTargetMappingTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.shared.io.scan.mapping;
+
+import java.io.File;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SingleTargetMappingTest {
+
+    @Test
+    void testGetTargetFilesShouldReturnEmptySetWhenSuffixDoesNotMatch() throws Exception {
+        SingleTargetMapping mapping = new SingleTargetMapping(".cs", "/foo");
+        File basedir = new File("target/");
+
+        Set<File> results = mapping.getTargetFiles(basedir, "path/to/file.apt");
+
+        assertTrue(results.isEmpty());
+    }
+
+    @Test
+    void testGetTargetFilesShouldReturnCorrectFileWhenSuffixMatches() throws Exception {
+        SingleTargetMapping mapping = new SingleTargetMapping(".cs", "/foo");
+        File basedir = new File("target/");
+
+        Set<File> results = mapping.getTargetFiles(basedir, "path/to/file.cs");
+
+        assertEquals(1, results.size());
+        assertEquals(new File(basedir, "/foo"), results.iterator().next());
+    }
+
+    @Test
+    void testGetTargetFilesShouldHandleNullSourceAndSuffixGracefully() {
+        SingleTargetMapping mapping = new SingleTargetMapping(null, "/foo");
+        File basedir = new File("target/");
+
+        assertDoesNotThrow(() -> {
+            Set<File> results = mapping.getTargetFiles(basedir, null);
+            assertTrue(results.isEmpty());
+        });
+    }
+}

--- a/src/test/java/org/apache/maven/shared/io/scan/mapping/SingleTargetMappingTest.java
+++ b/src/test/java/org/apache/maven/shared/io/scan/mapping/SingleTargetMappingTest.java
@@ -31,7 +31,7 @@ class SingleTargetMappingTest {
 
     @Test
     void testGetTargetFilesShouldReturnEmptySetWhenSuffixDoesNotMatch() throws Exception {
-        SingleTargetMapping mapping = new SingleTargetMapping(".cs", "/foo");
+        SingleTargetMapping mapping = new SingleTargetMapping(".cs", "foo");
         File basedir = new File("target/");
 
         Set<File> results = mapping.getTargetFiles(basedir, "path/to/file.apt");
@@ -41,13 +41,13 @@ class SingleTargetMappingTest {
 
     @Test
     void testGetTargetFilesShouldReturnCorrectFileWhenSuffixMatches() throws Exception {
-        SingleTargetMapping mapping = new SingleTargetMapping(".cs", "/foo");
+        SingleTargetMapping mapping = new SingleTargetMapping(".cs", "foo");
         File basedir = new File("target/");
 
         Set<File> results = mapping.getTargetFiles(basedir, "path/to/file.cs");
 
         assertEquals(1, results.size());
-        assertEquals(new File(basedir, "/foo"), results.iterator().next());
+        assertEquals(new File(basedir, "foo"), results.iterator().next());
     }
 
     @Test

--- a/src/test/java/org/apache/maven/shared/io/scan/mapping/SuffixMappingTest.java
+++ b/src/test/java/org/apache/maven/shared/io/scan/mapping/SuffixMappingTest.java
@@ -96,21 +96,4 @@ class SuffixMappingTest {
 
         assertTrue(results.isEmpty(), "Returned wrong number of target files.");
     }
-
-    @Test
-    void singleTargetMapper() throws Exception {
-        String base = "path/to/file";
-
-        File basedir = new File("target/");
-
-        SingleTargetMapping mapping = new SingleTargetMapping(".cs", "/foo");
-
-        Set<File> results = mapping.getTargetFiles(basedir, base + ".apt");
-
-        assertTrue(results.isEmpty());
-
-        results = mapping.getTargetFiles(basedir, base + ".cs");
-
-        assertEquals(1, results.size());
-    }
 }


### PR DESCRIPTION
Description
This pull request addresses a NullPointerException (NPE) in SingleTargetMapping.java that occurs when evaluating source.endsWith(sourceSuffix) if either source or sourceSuffix is passed as a null value.

To resolve this, a defensive guard clause has been implemented to return an empty set (Collections.emptySet()) immediately if any parameter validation fails, avoiding the crash.

Configuration Details / Changes
Fix Implementation: Added short-circuit null validation for source and sourceSuffix in SingleTargetMapping#getTargetFiles.

Test Isolation & Coverage:

Created a dedicated JUnit 5 test class SingleTargetMappingTest.java to explicitly cover suffix matching, non-matching, and null input edge cases.

Removed the legacy, misplaced test method singleTargetMapper() from SuffixMappingTest.java to clean up duplicate test footprints and enforce correct separation of concerns.

Style & Quality Gates: Fixed all checkstyle rules (avoiding star imports and matching method camelCase patterns) to ensure compliance with project conventions.

Closes #94 

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [x] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
