### PR TITLE
Fix NullPointerException in SuffixMapping.getTargetFiles

### DIFF
--- a/src/main/java/org/apache/maven/shared/io/scan/mapping/SuffixMapping.java
+++ b/src/main/java/org/apache/maven/shared/io/scan/mapping/SuffixMapping.java
@@ -56,7 +56,7 @@ public final class SuffixMapping implements SourceMapping {
     public Set<File> getTargetFiles(File targetDir, String source) {
         Set<File> targetFiles = new HashSet<>();
 
-        if (source.endsWith(sourceSuffix)) {
+        if (source != null && sourceSuffix != null && source.endsWith(sourceSuffix)) {
             String base = source.substring(0, source.length() - sourceSuffix.length());
 
             for (String suffix : targetSuffixes) {

--- a/src/test/java/org/apache/maven/shared/io/scan/mapping/SuffixMappingTest.java
+++ b/src/test/java/org/apache/maven/shared/io/scan/mapping/SuffixMappingTest.java
@@ -98,6 +98,28 @@ class SuffixMappingTest {
     }
 
     @Test
+    void shouldReturnNoTargetFilesWhenSourceSuffixIsNull() throws Exception {
+        File basedir = new File(".");
+
+        SuffixMapping mapping = new SuffixMapping(null, ".class");
+
+        Set<File> results = mapping.getTargetFiles(basedir, "path/to/file.java");
+
+        assertTrue(results.isEmpty(), "Returned wrong number of target files.");
+    }
+
+    @Test
+    void shouldReturnNoTargetFilesWhenSourceIsNull() throws Exception {
+        File basedir = new File(".");
+
+        SuffixMapping mapping = new SuffixMapping(".java", ".class");
+
+        Set<File> results = mapping.getTargetFiles(basedir, null);
+
+        assertTrue(results.isEmpty(), "Returned wrong number of target files.");
+    }
+
+    @Test
     void singleTargetMapper() throws Exception {
         String base = "path/to/file";
 


### PR DESCRIPTION
`SuffixMapping.getTargetFiles()` calls `source.endsWith(sourceSuffix)` unconditionally. Both `source` and `sourceSuffix` can be null through the public constructor (`SuffixMapping(String sourceSuffix, String targetSuffix)` takes no null checks), and either one being null throws an NPE:

```
java.lang.NullPointerException: Cannot invoke "String.endsWith(String)" because "source" is null
	at org.apache.maven.shared.io.scan.mapping.SuffixMapping.getTargetFiles(SuffixMapping.java:59)

java.lang.NullPointerException: Cannot invoke "String.length()" because "suffix" is null
	at java.base/java.lang.String.endsWith(String.java:2331)
	at org.apache.maven.shared.io.scan.mapping.SuffixMapping.getTargetFiles(SuffixMapping.java:59)
```

Fixes #93

### Changes

- Guard the `endsWith` call so a null `source` or `sourceSuffix` is treated as a non-match (returns an empty target set), matching the existing behavior for a suffix mismatch.
- Added two tests (`shouldReturnNoTargetFilesWhenSourceSuffixIsNull`, `shouldReturnNoTargetFilesWhenSourceIsNull`) that reproduce the NPE before the fix and pass after it.

`mvn test -Dtest=SuffixMappingTest` and `mvn verify` pass locally.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)