### PR TITLE
fix #96: close unclosed quote in unused tokens warning message   

### DIFF
--- a/src/main/java/org/apache/maven/shared/io/location/ArtifactLocatorStrategy.java
+++ b/src/main/java/org/apache/maven/shared/io/location/ArtifactLocatorStrategy.java
@@ -140,6 +140,8 @@ public class ArtifactLocatorStrategy implements LocatorStrategy {
                 for (int i = 5; i < parts.length; i++) {
                     messageHolder.append(":" + parts[i]);
                 }
+
+                messageHolder.append("\'");
             }
 
             Artifact artifact;


### PR DESCRIPTION
  ## Summary
  - Fixed a cosmetic defect in `ArtifactLocatorStrategy.java` where the diagnostic
    log message for unused tokens had an opening single quote but no closing quote.
  - The message now correctly reads: `Location specification has unused tokens: ':extra'`
    instead of: `Location specification has unused tokens: ':extra`

  ## Changes
  - `ArtifactLocatorStrategy.java` line 144: added `messageHolder.append("\'")`
    after the unused tokens loop to close the opening quote.

  ## Contribution Checklist
  - [x] Your pull request should address just one issue, without pulling in other changes.
  - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
  - [x] Each commit in the pull request should have a meaningful subject line and body.
    Note that commits might be squashed by a maintainer on merge.
  - [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
    *(Existing test `shouldResolveSpecWithMoreThanFiveTokens` covers the code path — all 82 tests pass.
    This is a cosmetic-only change with no behavioral logic change, so no new test is required.)*
  - [x] Run `mvn verify` to make sure basic checks pass.
    *(Ran `mvn surefire:test` — 82 tests, 0 failures, 0 errors. `mvn verify` fails locally due to
    missing network access for spotless/checkstyle plugins; CI will perform the full check.)*

  If your pull request is about ~20 lines of code you don't need to sign an
  [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
  please ask on the developers list.

  *(This PR changes 2 lines of code — no ICLA required.)*

  To make clear that you license your contribution under
  the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
  you have to acknowledge this by using the following check-box.

  - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

  Fixes #96