### PR TITLE
Validate ArtifactLocatorStrategy constructor inputs

### DIFF
--- a/src/main/java/org/apache/maven/shared/io/location/ArtifactLocatorStrategy.java
+++ b/src/main/java/org/apache/maven/shared/io/location/ArtifactLocatorStrategy.java
@@ -19,6 +19,7 @@
 package org.apache.maven.shared.io.location;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.factory.ArtifactFactory;
@@ -55,10 +56,7 @@ public class ArtifactLocatorStrategy implements LocatorStrategy {
             ArtifactResolver resolver,
             ArtifactRepository localRepository,
             List<ArtifactRepository> remoteRepositories) {
-        this.factory = factory;
-        this.resolver = resolver;
-        this.localRepository = localRepository;
-        this.remoteRepositories = remoteRepositories;
+        this(factory, resolver, localRepository, remoteRepositories, "jar", null);
     }
 
     /**
@@ -74,11 +72,7 @@ public class ArtifactLocatorStrategy implements LocatorStrategy {
             ArtifactRepository localRepository,
             List<ArtifactRepository> remoteRepositories,
             String defaultArtifactType) {
-        this.factory = factory;
-        this.resolver = resolver;
-        this.localRepository = localRepository;
-        this.remoteRepositories = remoteRepositories;
-        this.defaultArtifactType = defaultArtifactType;
+        this(factory, resolver, localRepository, remoteRepositories, defaultArtifactType, null);
     }
 
     /**
@@ -96,9 +90,9 @@ public class ArtifactLocatorStrategy implements LocatorStrategy {
             List<ArtifactRepository> remoteRepositories,
             String defaultArtifactType,
             String defaultClassifier) {
-        this.factory = factory;
-        this.resolver = resolver;
-        this.localRepository = localRepository;
+        this.factory = Objects.requireNonNull(factory, "factory");
+        this.resolver = Objects.requireNonNull(resolver, "resolver");
+        this.localRepository = Objects.requireNonNull(localRepository, "localRepository");
         this.remoteRepositories = remoteRepositories;
         this.defaultArtifactType = defaultArtifactType;
         this.defaultClassifier = defaultClassifier;

--- a/src/test/java/org/apache/maven/shared/io/location/ArtifactLocatorStrategyTest.java
+++ b/src/test/java/org/apache/maven/shared/io/location/ArtifactLocatorStrategyTest.java
@@ -42,6 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -76,6 +77,33 @@ class ArtifactLocatorStrategyTest {
         new ArtifactLocatorStrategy(factory, resolver, localRepository, Collections.EMPTY_LIST, "zip");
 
         verify(factory, resolver, localRepository);
+    }
+
+    @Test
+    void shouldRejectNullFactory() {
+        NullPointerException exception = assertThrows(
+                NullPointerException.class,
+                () -> new ArtifactLocatorStrategy(null, resolver, localRepository, Collections.EMPTY_LIST));
+
+        assertEquals("factory", exception.getMessage());
+    }
+
+    @Test
+    void shouldRejectNullResolver() {
+        NullPointerException exception = assertThrows(
+                NullPointerException.class,
+                () -> new ArtifactLocatorStrategy(factory, null, localRepository, Collections.EMPTY_LIST));
+
+        assertEquals("resolver", exception.getMessage());
+    }
+
+    @Test
+    void shouldRejectNullLocalRepository() {
+        NullPointerException exception = assertThrows(
+                NullPointerException.class,
+                () -> new ArtifactLocatorStrategy(factory, resolver, null, Collections.EMPTY_LIST));
+
+        assertEquals("localRepository", exception.getMessage());
     }
 
     @Test


### PR DESCRIPTION
﻿## Summary
- validate required `ArtifactLocatorStrategy` constructor dependencies up front
- delegate constructors through the full constructor so validation stays consistent
- add tests for null `factory`, `resolver`, and `localRepository` inputs

Fixes #91

## Validation
- `mvn -q -Dtest=ArtifactLocatorStrategyTest test`
- `mvn -q test`