### PR TITLE
fix #98: replace deleteOnExit() with explicit cleanup to prevent temp file leak

### DIFF
--- a/src/main/java/org/apache/maven/shared/io/download/DefaultDownloadManager.java
+++ b/src/main/java/org/apache/maven/shared/io/download/DefaultDownloadManager.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.maven.artifact.manager.WagonManager;
 import org.apache.maven.shared.io.logging.MessageHolder;
 import org.apache.maven.wagon.ConnectionException;
@@ -57,32 +58,157 @@ public class DefaultDownloadManager implements DownloadManager {
     private Map<String, File> cache = new ConcurrentHashMap<>();
 
     /**
+     * Shared parent of all download directories. One JVM shutdown hook deletes it.
+     */
+    private static File downloadRoot;
+
+    /**
+     * Whether the shutdown hook registration was already attempted. Keeps it to one hook.
+     */
+    private static boolean shutdownHookAttempted;
+
+    /**
+     * Number of shutdown hooks registered.
+     */
+    private static int registeredShutdownHooks;
+
+    /**
+     * @return how many JVM shutdown hooks this class registered.
+     */
+    static synchronized int registeredShutdownHooks() {
+        return registeredShutdownHooks;
+    }
+
+    /**
+     * This manager's own download directory, so {@link #cleanup()} only deletes its own files.
+     */
+    private File downloadDirectory;
+
+    /**
      * Create an instance of the {@code DefaultDownloadManager}.
      */
-    public DefaultDownloadManager() {
-        registerShutdownHook();
-    }
+    public DefaultDownloadManager() {}
 
     /**
      * @param wagonManager {@link org.apache.maven.repository.legacy.WagonManager}
      */
     public DefaultDownloadManager(WagonManager wagonManager) {
         this.wagonManager = wagonManager;
-        registerShutdownHook();
     }
 
     /**
-     * Registers a single JVM shutdown hook per manager instance that deletes all
-     * cached temporary download files at JVM exit. This avoids the memory leak
-     * caused by {@code File.deleteOnExit()}, which accumulates entries in the
-     * JVM-wide {@code DeleteOnExitHook} static set on every download invocation.
+     * Deletes the temporary files downloaded through this manager and empties its cache, so that
+     * subsequent requests download again. Calling this is optional: the files are removed when the
+     * JVM exits anyway. It is worth calling in a long-lived JVM, such as a Maven daemon or an
+     * embedded build, once the downloaded files are no longer needed. Do not call it while a
+     * download is in progress on another thread, as that download writes into the directory being
+     * removed.
      */
-    private void registerShutdownHook() {
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            for (File file : cache.values()) {
-                file.delete();
-            }
-        }));
+    public void cleanup() {
+        cache.clear();
+
+        File directory;
+        synchronized (this) {
+            directory = downloadDirectory;
+            downloadDirectory = null;
+        }
+
+        if (directory != null) {
+            FileUtils.deleteQuietly(directory);
+        }
+    }
+
+    /**
+     * @return the directory of this manager, creating it, the shared root and the shutdown hook that
+     *         removes the root on first use.
+     * @throws IOException if the directory cannot be created.
+     */
+    private synchronized File downloadDirectory() throws IOException {
+        if (downloadDirectory == null || !downloadDirectory.isDirectory()) {
+            downloadDirectory = Files.createTempDirectory(downloadRoot().toPath(), "manager-")
+                    .toFile();
+        }
+
+        return downloadDirectory;
+    }
+
+    private static synchronized File downloadRoot() throws IOException {
+        // Recreate the root if something else deleted it, such as a temp dir sweeper.
+        if (downloadRoot == null || !downloadRoot.isDirectory()) {
+            downloadRoot =
+                    Files.createTempDirectory("maven-shared-io-downloads-").toFile();
+            registerShutdownHook();
+        }
+
+        return downloadRoot;
+    }
+
+    /**
+     * Registers, at most once, the hook that removes {@link #downloadRoot} at JVM exit. Registering
+     * one hook for the lifetime of the class, instead of one per root, is what keeps the JVM's hook
+     * set from growing: a root that a temp dir sweeper removes is replaced without a second hook.
+     */
+    private static void registerShutdownHook() {
+        if (shutdownHookAttempted) {
+            return;
+        }
+
+        // Set before the attempt, so a failure is not retried on every recreation of the root.
+        shutdownHookAttempted = true;
+
+        preloadDeleteClasses();
+
+        Thread hook = new Thread(DefaultDownloadManager::deleteDownloadRoot, "maven-shared-io-download-cleanup");
+
+        // The hook lives until JVM exit, so give it as few references as possible. The inherited
+        // context class loader is a plugin class realm in Maven and would be kept alive for the
+        // whole run of a long-lived JVM.
+        hook.setContextClassLoader(null);
+
+        try {
+            Runtime.getRuntime().addShutdownHook(hook);
+            registeredShutdownHooks++;
+        } catch (IllegalStateException e) {
+            // Already shutting down, so no hook can be added. Leave the files to the OS temp cleanup.
+        } catch (SecurityException e) {
+            // Not allowed to register a hook. Downloading must still work, so fall back to the
+            // operating system's temp directory cleanup, as above.
+        }
+    }
+
+    /**
+     * Deletes a throwaway directory tree so the classes {@link #deleteDownloadRoot()} needs are
+     * loaded up front. At JVM exit the class loader may be closed, {@link FileUtils} would fail to
+     * load and the hook would delete nothing.
+     * Called while holding the class lock, so {@link #downloadRoot} is the root just created.
+     */
+    private static void preloadDeleteClasses() {
+        File warmUp = new File(downloadRoot, ".warm-up");
+
+        try {
+            Files.createDirectories(warmUp.toPath().resolve("nested"));
+            Files.createFile(warmUp.toPath().resolve("nested/file"));
+        } catch (IOException e) {
+            // Nothing to walk, so fewer classes load. The hook is no worse off.
+        }
+
+        FileUtils.deleteQuietly(warmUp);
+    }
+
+    /**
+     * Deletes the current download root, ignoring failures. Called only by the shutdown hook.
+     * The lock only reads {@link #downloadRoot}; the deletion itself need not be exclusive, because
+     * a concurrent {@link #cleanup()} also uses {@link FileUtils#deleteQuietly(File)}.
+     */
+    private static void deleteDownloadRoot() {
+        File root;
+        synchronized (DefaultDownloadManager.class) {
+            root = downloadRoot;
+        }
+
+        if (root != null) {
+            FileUtils.deleteQuietly(root);
+        }
     }
 
     /** {@inheritDoc} */
@@ -93,7 +219,7 @@ public class DefaultDownloadManager implements DownloadManager {
     /** {@inheritDoc} */
     public File download(String url, List<TransferListener> transferListeners, MessageHolder messageHolder)
             throws DownloadFailedException {
-        File downloaded = (File) cache.get(url);
+        File downloaded = cache.get(url);
 
         if (downloaded != null && downloaded.exists()) {
             messageHolder.addMessage("Using cached download: " + downloaded.getAbsolutePath());
@@ -120,8 +246,10 @@ public class DefaultDownloadManager implements DownloadManager {
         messageHolder.addMessage("Using wagon: " + wagon + " to download: " + url);
 
         try {
-            // create the landing file in /tmp for the downloaded source archive
-            downloaded = Files.createTempFile("download-", null).toFile();
+            // create the landing file for the downloaded source archive, in the temp directory that
+            // is removed as a whole at JVM exit, so no per-file exit hook is needed.
+            downloaded = Files.createTempFile(downloadDirectory().toPath(), "download-", null)
+                    .toFile();
         } catch (IOException e) {
             throw new DownloadFailedException(url, "Failed to create temporary file target for download.", e);
         }
@@ -153,7 +281,7 @@ public class DefaultDownloadManager implements DownloadManager {
 
         messageHolder.addMessage("Connecting to: " + repo.getHost() + "(baseUrl: " + repo.getUrl() + ")");
 
-        boolean success = false;
+        boolean retainTempFile = false;
         boolean connected = false;
         try {
             wagon.connect(
@@ -167,9 +295,21 @@ public class DefaultDownloadManager implements DownloadManager {
             wagon.get(remotePath, downloaded);
 
             // cache this for later download requests to the same instance...
-            cache.put(url, downloaded);
+            File cached = cache.putIfAbsent(url, downloaded);
 
-            success = true;
+            if (cached != null && cached.exists()) {
+                // Another thread cached this URL first. Return its file, which callers may already
+                // be using, and let the finally block delete this copy.
+                return cached;
+            }
+
+            if (cached != null) {
+                // The cached file is gone, so replace the entry with this one. Losing this race is
+                // harmless: either file is valid and both are deleted with the temp directory.
+                cache.replace(url, cached, downloaded);
+            }
+
+            retainTempFile = true;
             return downloaded;
         } catch (ConnectionException e) {
             throw new DownloadFailedException(url, "Download failed", e);
@@ -182,23 +322,26 @@ public class DefaultDownloadManager implements DownloadManager {
         } catch (AuthorizationException e) {
             throw new DownloadFailedException(url, "Download failed", e);
         } finally {
-            // On failure, delete the temp file immediately to avoid leaving orphaned files.
-            // Successfully downloaded files are cleaned up by the shutdown hook registered
-            // in registerShutdownHook().
-            if (!success && downloaded != null) {
+            // Delete the temp file unless the cache now holds it. Covers a failed download and a
+            // lost race to cache the same URL.
+            if (!retainTempFile) {
                 downloaded.delete();
             }
 
-            // ensure the Wagon instance is closed out properly (only if connect succeeded)
-            if (wagon != null && connected) {
-                try {
-                    messageHolder.addMessage("Disconnecting.");
+            if (wagon != null) {
+                // Only disconnect if the connection was actually established.
+                if (connected) {
+                    try {
+                        messageHolder.addMessage("Disconnecting.");
 
-                    wagon.disconnect();
-                } catch (ConnectionException e) {
-                    messageHolder.addMessage("Failed to disconnect wagon for: " + url, e);
+                        wagon.disconnect();
+                    } catch (ConnectionException e) {
+                        messageHolder.addMessage("Failed to disconnect wagon for: " + url, e);
+                    }
                 }
 
+                // Listeners are added before connecting, so remove them even if connecting failed.
+                // Otherwise they stay attached to a Wagon that may be reused.
                 for (Iterator<TransferListener> it = transferListeners.iterator(); it.hasNext(); ) {
                     wagon.removeTransferListener(it.next());
                 }

--- a/src/main/java/org/apache/maven/shared/io/download/DefaultDownloadManager.java
+++ b/src/main/java/org/apache/maven/shared/io/download/DefaultDownloadManager.java
@@ -59,13 +59,30 @@ public class DefaultDownloadManager implements DownloadManager {
     /**
      * Create an instance of the {@code DefaultDownloadManager}.
      */
-    public DefaultDownloadManager() {}
+    public DefaultDownloadManager() {
+        registerShutdownHook();
+    }
 
     /**
      * @param wagonManager {@link org.apache.maven.repository.legacy.WagonManager}
      */
     public DefaultDownloadManager(WagonManager wagonManager) {
         this.wagonManager = wagonManager;
+        registerShutdownHook();
+    }
+
+    /**
+     * Registers a single JVM shutdown hook per manager instance that deletes all
+     * cached temporary download files at JVM exit. This avoids the memory leak
+     * caused by {@code File.deleteOnExit()}, which accumulates entries in the
+     * JVM-wide {@code DeleteOnExitHook} static set on every download invocation.
+     */
+    private void registerShutdownHook() {
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            for (File file : cache.values()) {
+                file.delete();
+            }
+        }));
     }
 
     /** {@inheritDoc} */
@@ -105,9 +122,6 @@ public class DefaultDownloadManager implements DownloadManager {
         try {
             // create the landing file in /tmp for the downloaded source archive
             downloaded = Files.createTempFile("download-", null).toFile();
-
-            // delete when the JVM exits, to avoid polluting the temp dir...
-            downloaded.deleteOnExit();
         } catch (IOException e) {
             throw new DownloadFailedException(url, "Failed to create temporary file target for download.", e);
         }
@@ -139,26 +153,28 @@ public class DefaultDownloadManager implements DownloadManager {
 
         messageHolder.addMessage("Connecting to: " + repo.getHost() + "(baseUrl: " + repo.getUrl() + ")");
 
+        boolean success = false;
+        boolean connected = false;
         try {
             wagon.connect(
                     repo,
                     wagonManager.getAuthenticationInfo(repo.getId()),
                     wagonManager.getProxy(sourceUrl.getProtocol()));
-        } catch (ConnectionException e) {
-            throw new DownloadFailedException(url, "Download failed", e);
-        } catch (AuthenticationException e) {
-            throw new DownloadFailedException(url, "Download failed", e);
-        }
+            connected = true;
 
-        messageHolder.addMessage("Getting: " + remotePath);
+            messageHolder.addMessage("Getting: " + remotePath);
 
-        try {
             wagon.get(remotePath, downloaded);
 
             // cache this for later download requests to the same instance...
             cache.put(url, downloaded);
 
+            success = true;
             return downloaded;
+        } catch (ConnectionException e) {
+            throw new DownloadFailedException(url, "Download failed", e);
+        } catch (AuthenticationException e) {
+            throw new DownloadFailedException(url, "Download failed", e);
         } catch (TransferFailedException e) {
             throw new DownloadFailedException(url, "Download failed", e);
         } catch (ResourceDoesNotExistException e) {
@@ -166,8 +182,15 @@ public class DefaultDownloadManager implements DownloadManager {
         } catch (AuthorizationException e) {
             throw new DownloadFailedException(url, "Download failed", e);
         } finally {
-            // ensure the Wagon instance is closed out properly.
-            if (wagon != null) {
+            // On failure, delete the temp file immediately to avoid leaving orphaned files.
+            // Successfully downloaded files are cleaned up by the shutdown hook registered
+            // in registerShutdownHook().
+            if (!success && downloaded != null) {
+                downloaded.delete();
+            }
+
+            // ensure the Wagon instance is closed out properly (only if connect succeeded)
+            if (wagon != null && connected) {
                 try {
                     messageHolder.addMessage("Disconnecting.");
 

--- a/src/test/java/org/apache/maven/shared/io/download/DefaultDownloadManagerTest.java
+++ b/src/test/java/org/apache/maven/shared/io/download/DefaultDownloadManagerTest.java
@@ -21,8 +21,11 @@ package org.apache.maven.shared.io.download;
 import java.io.File;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -55,8 +58,10 @@ import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.newCapture;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
+import org.easymock.Capture;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -509,6 +514,82 @@ class DefaultDownloadManagerTest {
 
         executor.shutdown();
         verify(wagon, wagonManager);
+    }
+
+    @Test
+    void shouldDeleteTempFileOnConnectionFailure() throws Exception {
+        File tempFile = Files.createTempFile("download-source", "test").toFile();
+        tempFile.deleteOnExit();
+
+        setupMocksWithWagonConnectionException(new ConnectionException("connect error"));
+
+        replay(wagon, wagonManager);
+
+        DownloadManager downloadManager = new DefaultDownloadManager(wagonManager);
+
+        File tempDir = new File(System.getProperty("java.io.tmpdir"));
+        Set<String> filesBefore = listDownloadTempFiles(tempDir);
+
+        try {
+            downloadManager.download(tempFile.toURI().toASCIIString(), new DefaultMessageHolder());
+            fail("should have failed to connect wagon.");
+        } catch (DownloadFailedException e) {
+            assertTrue(ExceptionUtils.getStackTrace(e).contains("ConnectionException"));
+        }
+
+        Set<String> filesAfter = listDownloadTempFiles(tempDir);
+        filesAfter.removeAll(filesBefore);
+        assertTrue(filesAfter.isEmpty(), "Temp file must be deleted immediately when connection fails, not leaked");
+
+        verify(wagon, wagonManager);
+    }
+
+    @Test
+    void shouldDeleteTempFileOnTransferFailure() throws Exception {
+        File tempFile = Files.createTempFile("download-source", "test").toFile();
+        tempFile.deleteOnExit();
+
+        expect(wagonManager.getWagon("file")).andReturn(wagon);
+        expect(wagonManager.getAuthenticationInfo(anyString())).andReturn(null);
+        expect(wagonManager.getProxy(anyString())).andReturn(null);
+        try {
+            wagon.connect(anyObject(Repository.class), anyObject(AuthenticationInfo.class), anyObject(ProxyInfo.class));
+        } catch (ConnectionException | AuthenticationException e) {
+            fail("This shouldn't happen!!");
+        }
+
+        Capture<File> capturedTempFile = newCapture();
+        try {
+            wagon.get(anyString(), capture(capturedTempFile));
+            expectLastCall().andThrow(new TransferFailedException("bad transfer"));
+        } catch (TransferFailedException | AuthorizationException | ResourceDoesNotExistException e) {
+            fail("This shouldn't happen!!");
+        }
+
+        assertDoesNotThrow(() -> wagon.disconnect(), "This shouldn't happen!!");
+
+        replay(wagon, wagonManager);
+
+        DownloadManager downloadManager = new DefaultDownloadManager(wagonManager);
+
+        try {
+            downloadManager.download(tempFile.toURI().toASCIIString(), new DefaultMessageHolder());
+            fail("should have thrown DownloadFailedException");
+        } catch (DownloadFailedException e) {
+            assertTrue(ExceptionUtils.getStackTrace(e).contains("TransferFailedException"));
+        }
+
+        assertTrue(capturedTempFile.hasCaptured(), "wagon.get() should have been called");
+        assertFalse(
+                capturedTempFile.getValue().exists(),
+                "Temp file must be deleted immediately when transfer fails, not leaked");
+
+        verify(wagon, wagonManager);
+    }
+
+    private Set<String> listDownloadTempFiles(File tempDir) {
+        String[] files = tempDir.list((dir, name) -> name.startsWith("download-") && name.endsWith(".tmp"));
+        return files == null ? new HashSet<>() : new HashSet<>(Arrays.asList(files));
     }
 
     private void setupDefaultMockConfiguration() {

--- a/src/test/java/org/apache/maven/shared/io/download/DefaultDownloadManagerTest.java
+++ b/src/test/java/org/apache/maven/shared/io/download/DefaultDownloadManagerTest.java
@@ -19,16 +19,25 @@
 package org.apache.maven.shared.io.download;
 
 import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.maven.artifact.manager.WagonManager;
@@ -58,11 +67,11 @@ import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.newCapture;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
-import org.easymock.Capture;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -527,8 +536,7 @@ class DefaultDownloadManagerTest {
 
         DownloadManager downloadManager = new DefaultDownloadManager(wagonManager);
 
-        File tempDir = new File(System.getProperty("java.io.tmpdir"));
-        Set<String> filesBefore = listDownloadTempFiles(tempDir);
+        Set<String> filesBefore = listDownloadTempFiles();
 
         try {
             downloadManager.download(tempFile.toURI().toASCIIString(), new DefaultMessageHolder());
@@ -537,7 +545,7 @@ class DefaultDownloadManagerTest {
             assertTrue(ExceptionUtils.getStackTrace(e).contains("ConnectionException"));
         }
 
-        Set<String> filesAfter = listDownloadTempFiles(tempDir);
+        Set<String> filesAfter = listDownloadTempFiles();
         filesAfter.removeAll(filesBefore);
         assertTrue(filesAfter.isEmpty(), "Temp file must be deleted immediately when connection fails, not leaked");
 
@@ -587,9 +595,419 @@ class DefaultDownloadManagerTest {
         verify(wagon, wagonManager);
     }
 
-    private Set<String> listDownloadTempFiles(File tempDir) {
-        String[] files = tempDir.list((dir, name) -> name.startsWith("download-") && name.endsWith(".tmp"));
-        return files == null ? new HashSet<>() : new HashSet<>(Arrays.asList(files));
+    @Test
+    void shouldDownloadIntoTheSharedTempDirectoryInsteadOfRegisteringDeleteOnExit() throws Exception {
+        File tempFile = Files.createTempFile("download-source", "test").toFile();
+        tempFile.deleteOnExit();
+
+        expect(wagonManager.getWagon("file")).andReturn(wagon);
+        expect(wagonManager.getAuthenticationInfo(anyString())).andReturn(null);
+        expect(wagonManager.getProxy(anyString())).andReturn(null);
+        wagon.connect(anyObject(Repository.class), anyObject(AuthenticationInfo.class), anyObject(ProxyInfo.class));
+
+        Capture<File> capturedTempFile = newCapture();
+        wagon.get(anyString(), capture(capturedTempFile));
+        wagon.disconnect();
+
+        replay(wagon, wagonManager);
+
+        DownloadManager downloadManager = new DefaultDownloadManager(wagonManager);
+
+        downloadManager.download(tempFile.toURI().toASCIIString(), new DefaultMessageHolder());
+
+        // Downloads live under one directory that a single shutdown hook removes, so the amount of
+        // JVM shutdown bookkeeping stays constant instead of growing with every download.
+        Path downloadPath = capturedTempFile.getValue().toPath().toAbsolutePath();
+        Path tempRoot = Paths.get(System.getProperty("java.io.tmpdir")).toAbsolutePath();
+
+        assertTrue(downloadPath.startsWith(tempRoot), "Download must stay in the temp directory: " + downloadPath);
+        assertTrue(
+                tempRoot.relativize(downloadPath).getName(0).toString().startsWith("maven-shared-io-downloads-"),
+                "Download must land in the shared download directory: " + downloadPath);
+
+        verify(wagon, wagonManager);
+    }
+
+    @Test
+    void shouldDownloadAgainWhenTheCachedFileWasDeleted() throws Exception {
+        File tempFile = Files.createTempFile("download-source", "test").toFile();
+        tempFile.deleteOnExit();
+
+        expect(wagonManager.getWagon("file")).andReturn(wagon).anyTimes();
+        expect(wagonManager.getAuthenticationInfo(anyString())).andReturn(null).anyTimes();
+        expect(wagonManager.getProxy(anyString())).andReturn(null).anyTimes();
+        wagon.connect(anyObject(Repository.class), anyObject(AuthenticationInfo.class), anyObject(ProxyInfo.class));
+        expectLastCall().anyTimes();
+        wagon.get(anyString(), anyObject(File.class));
+        expectLastCall().anyTimes();
+        wagon.disconnect();
+        expectLastCall().anyTimes();
+
+        replay(wagon, wagonManager);
+
+        DownloadManager downloadManager = new DefaultDownloadManager(wagonManager);
+
+        String url = tempFile.toURI().toASCIIString();
+
+        File first = downloadManager.download(url, new DefaultMessageHolder());
+        assertTrue(first.delete(), "should have deleted the downloaded file");
+
+        File second = downloadManager.download(url, new DefaultMessageHolder());
+
+        assertTrue(second.exists(), "must not hand back the stale cache entry of a deleted file");
+        assertFalse(first.equals(second), "must download to a fresh file");
+
+        // The stale entry has been replaced, so the next request is served from the cache again.
+        assertSame(second, downloadManager.download(url, new DefaultMessageHolder()));
+
+        verify(wagon, wagonManager);
+    }
+
+    @Test
+    void shouldDeleteDownloadedFilesOnCleanup() throws Exception {
+        File tempFile = Files.createTempFile("download-source", "test").toFile();
+        tempFile.deleteOnExit();
+
+        setupDefaultMockConfiguration();
+
+        replay(wagon, wagonManager);
+
+        DefaultDownloadManager downloadManager = new DefaultDownloadManager(wagonManager);
+
+        File downloaded = downloadManager.download(tempFile.toURI().toASCIIString(), new DefaultMessageHolder());
+        assertTrue(downloaded.exists());
+
+        downloadManager.cleanup();
+
+        assertFalse(downloaded.exists(), "cleanup() must delete the downloaded file");
+        assertFalse(downloaded.getParentFile().exists(), "cleanup() must delete the manager's directory");
+
+        verify(wagon, wagonManager);
+    }
+
+    @Test
+    void shouldStillBeUsableAfterCleanup() throws Exception {
+        File tempFile = Files.createTempFile("download-source", "test").toFile();
+        tempFile.deleteOnExit();
+
+        expect(wagonManager.getWagon("file")).andReturn(wagon).anyTimes();
+        expect(wagonManager.getAuthenticationInfo(anyString())).andReturn(null).anyTimes();
+        expect(wagonManager.getProxy(anyString())).andReturn(null).anyTimes();
+        wagon.connect(anyObject(Repository.class), anyObject(AuthenticationInfo.class), anyObject(ProxyInfo.class));
+        expectLastCall().anyTimes();
+        wagon.get(anyString(), anyObject(File.class));
+        expectLastCall().anyTimes();
+        wagon.disconnect();
+        expectLastCall().anyTimes();
+
+        replay(wagon, wagonManager);
+
+        DefaultDownloadManager downloadManager = new DefaultDownloadManager(wagonManager);
+
+        String url = tempFile.toURI().toASCIIString();
+
+        downloadManager.download(url, new DefaultMessageHolder());
+        downloadManager.cleanup();
+
+        File afterCleanup = downloadManager.download(url, new DefaultMessageHolder());
+
+        assertTrue(afterCleanup.exists(), "must download into a freshly created directory after cleanup()");
+
+        verify(wagon, wagonManager);
+    }
+
+    @Test
+    void shouldNotDeleteTheFilesOfAnotherManagerOnCleanup() throws Exception {
+        File tempFile = Files.createTempFile("download-source", "test").toFile();
+        tempFile.deleteOnExit();
+
+        expect(wagonManager.getWagon("file")).andReturn(wagon).anyTimes();
+        expect(wagonManager.getAuthenticationInfo(anyString())).andReturn(null).anyTimes();
+        expect(wagonManager.getProxy(anyString())).andReturn(null).anyTimes();
+        wagon.connect(anyObject(Repository.class), anyObject(AuthenticationInfo.class), anyObject(ProxyInfo.class));
+        expectLastCall().anyTimes();
+        wagon.get(anyString(), anyObject(File.class));
+        expectLastCall().anyTimes();
+        wagon.disconnect();
+        expectLastCall().anyTimes();
+
+        replay(wagon, wagonManager);
+
+        String url = tempFile.toURI().toASCIIString();
+
+        DefaultDownloadManager first = new DefaultDownloadManager(wagonManager);
+        DefaultDownloadManager second = new DefaultDownloadManager(wagonManager);
+
+        File keptFile = first.download(url, new DefaultMessageHolder());
+        File droppedFile = second.download(url, new DefaultMessageHolder());
+
+        second.cleanup();
+
+        assertFalse(droppedFile.exists(), "cleanup() must delete the files of its own manager");
+        assertTrue(keptFile.exists(), "cleanup() must not delete the files of another manager");
+
+        first.cleanup();
+
+        verify(wagon, wagonManager);
+    }
+
+    @Test
+    void shouldRegisterAtMostOneShutdownHookHoweverManyDownloadsAndManagers() throws Exception {
+        File tempFile = Files.createTempFile("download-source", "test").toFile();
+        tempFile.deleteOnExit();
+
+        expectAnyNumberOfDownloads();
+
+        String url = tempFile.toURI().toASCIIString();
+
+        // Trigger the first download so that the root, and its hook, exist before counting.
+        DefaultDownloadManager warmUp = new DefaultDownloadManager(wagonManager);
+        warmUp.download(url, new DefaultMessageHolder());
+
+        int hooksAfterFirstDownload = DefaultDownloadManager.registeredShutdownHooks();
+
+        assertEquals(1, hooksAfterFirstDownload, "the root must be removed by a single shutdown hook");
+
+        List<DefaultDownloadManager> managers = new ArrayList<>();
+
+        for (int i = 0; i < 25; i++) {
+            DefaultDownloadManager manager = new DefaultDownloadManager(wagonManager);
+            managers.add(manager);
+
+            manager.download(url, new DefaultMessageHolder());
+            manager.download(url + "?run=" + i, new DefaultMessageHolder());
+            manager.cleanup();
+            manager.download(url, new DefaultMessageHolder());
+        }
+
+        assertEquals(
+                hooksAfterFirstDownload,
+                DefaultDownloadManager.registeredShutdownHooks(),
+                "downloads, managers and cleanup() must not add shutdown hooks");
+
+        for (DefaultDownloadManager manager : managers) {
+            manager.cleanup();
+        }
+
+        warmUp.cleanup();
+
+        verify(wagon, wagonManager);
+    }
+
+    @Test
+    void shouldNotRegisterAnotherShutdownHookWhenTheRootIsRemovedBehindOurBack() throws Exception {
+        File tempFile = Files.createTempFile("download-source", "test").toFile();
+        tempFile.deleteOnExit();
+
+        expectAnyNumberOfDownloads();
+
+        String url = tempFile.toURI().toASCIIString();
+
+        DefaultDownloadManager downloadManager = new DefaultDownloadManager(wagonManager);
+        downloadManager.download(url, new DefaultMessageHolder());
+
+        int hooksBefore = DefaultDownloadManager.registeredShutdownHooks();
+
+        // A temp dir sweeper removes the whole root between downloads, repeatedly.
+        for (int i = 0; i < 25; i++) {
+            for (Path root : listDownloadRoots()) {
+                deleteRecursively(root);
+            }
+
+            File downloaded = downloadManager.download(url + "?sweep=" + i, new DefaultMessageHolder());
+
+            assertTrue(downloaded.exists(), "must recreate the root and keep downloading after a sweep");
+        }
+
+        assertEquals(
+                hooksBefore,
+                DefaultDownloadManager.registeredShutdownHooks(),
+                "recreating the root must reuse the existing shutdown hook, not add one per root");
+
+        downloadManager.cleanup();
+
+        verify(wagon, wagonManager);
+    }
+
+    @Test
+    void shouldDeleteNestedDirectoriesOnCleanupWithoutFollowingSymbolicLinks() throws Exception {
+        File tempFile = Files.createTempFile("download-source", "test").toFile();
+        tempFile.deleteOnExit();
+
+        expectAnyNumberOfDownloads();
+
+        DefaultDownloadManager downloadManager = new DefaultDownloadManager(wagonManager);
+
+        File downloaded = downloadManager.download(tempFile.toURI().toASCIIString(), new DefaultMessageHolder());
+
+        // Whatever a wagon leaves in the download directory has to go too, including a subdirectory
+        // and a link pointing outside the tree, whose target must survive.
+        Path directory = downloaded.toPath().getParent();
+        Path nested = Files.createDirectories(directory.resolve("nested/deeper"));
+        Path nestedFile = Files.createFile(nested.resolve("leftover.tmp"));
+
+        Path outsideTarget = Files.createTempFile("outside-target", ".tmp");
+        outsideTarget.toFile().deleteOnExit();
+
+        Path link = directory.resolve("link-to-outside");
+        boolean linkCreated;
+        try {
+            Files.createSymbolicLink(link, outsideTarget);
+            linkCreated = true;
+        } catch (IOException | UnsupportedOperationException e) {
+            // Some platforms need a privilege for this; the rest of the assertions still apply.
+            linkCreated = false;
+        }
+
+        downloadManager.cleanup();
+
+        assertFalse(Files.exists(nestedFile), "cleanup() must delete files in nested directories");
+        assertFalse(Files.exists(directory), "cleanup() must delete the download directory itself");
+
+        if (linkCreated) {
+            assertTrue(Files.exists(outsideTarget), "cleanup() must not follow a symbolic link out of the tree");
+        }
+
+        verify(wagon, wagonManager);
+    }
+
+    @Test
+    void shouldDeleteTheRootWhenTheShutdownHookCanNoLongerLoadClasses() throws Exception {
+        // The hook runs at JVM exit, when the class loader that defined DefaultDownloadManager may
+        // already be closed, as a Maven plugin realm is at the end of a build. A class the hook only
+        // needs then, commons-io for one, could no longer be resolved, so the hook would fail and
+        // delete nothing. Load the manager in isolation, hide commons-io once the root exists, and
+        // check the hook still deletes: it must load what it needs before it is registered.
+        URL classes = DefaultDownloadManager.class
+                .getProtectionDomain()
+                .getCodeSource()
+                .getLocation();
+
+        HidingClassLoader hiding = new HidingClassLoader(DefaultDownloadManagerTest.class.getClassLoader());
+
+        try (URLClassLoader isolated = new URLClassLoader(new URL[] {classes}, hiding)) {
+            Class<?> isolatedManager = isolated.loadClass(DefaultDownloadManager.class.getName());
+
+            assertSame(isolated, isolatedManager.getClassLoader(), "the manager must come from the isolated loader");
+
+            Method downloadDirectory = isolatedManager.getDeclaredMethod("downloadDirectory");
+            downloadDirectory.setAccessible(true);
+            Method deleteDownloadRoot = isolatedManager.getDeclaredMethod("deleteDownloadRoot");
+            deleteDownloadRoot.setAccessible(true);
+
+            File directory = (File)
+                    downloadDirectory.invoke(isolatedManager.getConstructor().newInstance());
+            Path downloaded = Files.createFile(directory.toPath().resolve("download-0"));
+            Path nested = Files.createDirectories(directory.toPath().resolve("nested"));
+            Path nestedFile = Files.createFile(nested.resolve("leftover.tmp"));
+
+            // Stand in for the closed plugin realm: from here on no commons-io class can be loaded.
+            // Classes the manager already resolved stay usable, exactly as they do in a closed realm,
+            // which is why the manager has to resolve them before the hook is registered.
+            hiding.hideCommonsIo();
+
+            assertThrows(
+                    ClassNotFoundException.class,
+                    () -> isolated.loadClass("org.apache.commons.io.monitor.FileAlterationMonitor"),
+                    "no commons-io class may still be loaded through the isolated loader by now");
+
+            deleteDownloadRoot.invoke(null);
+
+            assertFalse(Files.exists(downloaded), "the shutdown hook must delete the downloaded files");
+            assertFalse(Files.exists(nestedFile), "the shutdown hook must delete nested files");
+            assertFalse(Files.exists(directory.toPath()), "the shutdown hook must delete the download directory");
+            assertFalse(Files.exists(directory.toPath().getParent()), "the shutdown hook must delete the root itself");
+        }
+    }
+
+    /**
+     * Hides the download package, so that the child loader has to define it itself, and hides
+     * commons-io from {@link #hideCommonsIo()} on, standing in for a plugin realm that is closed
+     * while the shutdown hook runs. Everything else comes from the test's own loader.
+     */
+    private static final class HidingClassLoader extends ClassLoader {
+
+        private volatile boolean commonsIoHidden;
+
+        HidingClassLoader(ClassLoader parent) {
+            super(parent);
+        }
+
+        void hideCommonsIo() {
+            commonsIoHidden = true;
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            if (name.startsWith("org.apache.maven.shared.io.download.")
+                    || (commonsIoHidden && name.startsWith("org.apache.commons.io."))) {
+                throw new ClassNotFoundException(name + " is hidden by this test");
+            }
+
+            return super.loadClass(name, resolve);
+        }
+    }
+
+    private void expectAnyNumberOfDownloads() {
+        assertDoesNotThrow(
+                () -> expect(wagonManager.getWagon("file")).andReturn(wagon).anyTimes(), "This shouldn't happen!!");
+
+        expect(wagonManager.getAuthenticationInfo(anyString())).andReturn(null).anyTimes();
+        expect(wagonManager.getProxy(anyString())).andReturn(null).anyTimes();
+
+        assertDoesNotThrow(
+                () -> {
+                    wagon.connect(
+                            anyObject(Repository.class),
+                            anyObject(AuthenticationInfo.class),
+                            anyObject(ProxyInfo.class));
+                    expectLastCall().anyTimes();
+
+                    wagon.get(anyString(), anyObject(File.class));
+                    expectLastCall().anyTimes();
+
+                    wagon.disconnect();
+                    expectLastCall().anyTimes();
+                },
+                "This shouldn't happen!!");
+
+        replay(wagon, wagonManager);
+    }
+
+    private List<Path> listDownloadRoots() throws Exception {
+        Path tempRoot = Paths.get(System.getProperty("java.io.tmpdir"));
+        List<Path> roots = new ArrayList<>();
+
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(tempRoot, "maven-shared-io-downloads-*")) {
+            for (Path root : stream) {
+                roots.add(root);
+            }
+        }
+
+        return roots;
+    }
+
+    private void deleteRecursively(Path path) throws Exception {
+        try (Stream<Path> paths = Files.walk(path)) {
+            for (Path candidate : paths.sorted(Comparator.reverseOrder()).collect(Collectors.toList())) {
+                Files.deleteIfExists(candidate);
+            }
+        }
+    }
+
+    private Set<String> listDownloadTempFiles() throws Exception {
+        Path tempRoot = Paths.get(System.getProperty("java.io.tmpdir"));
+        Set<String> files = new HashSet<>();
+
+        try (DirectoryStream<Path> roots = Files.newDirectoryStream(tempRoot, "maven-shared-io-downloads-*")) {
+            for (Path root : roots) {
+                try (Stream<Path> paths = Files.walk(root)) {
+                    paths.filter(Files::isRegularFile).map(Path::toString).forEach(files::add);
+                }
+            }
+        }
+
+        return files;
     }
 
     private void setupDefaultMockConfiguration() {


### PR DESCRIPTION
Fixes #98

## Problem

`DefaultDownloadManager.download()` registered every temporary download file with
`File.deleteOnExit()`. Each call adds an entry to the JVM-wide static
`java.io.DeleteOnExitHook` set, and entries are never removed during the JVM's
lifetime — they are only iterated at shutdown. Over many invocations this caused:

- **Unbounded memory growth** — one retained entry, with its path string, per downloaded file
- **Shutdown-time bookkeeping** proportional to the number of downloads

## Fix

`deleteOnExit()` is removed. Cleanup is now handled by three mechanisms:

**1. One temp directory, one shutdown hook (O(1) instead of O(downloads))**

All downloads land in a single lazily-created temp directory
(`maven-shared-io-downloads-*`), and exactly one shutdown hook removes that
directory recursively. Nothing is registered per file, so the amount of retained
state stays constant no matter how many files are downloaded. Each manager
instance gets its own subdirectory, which is what allows per-instance cleanup
(below) without touching another instance's files. No static field ever
references an individual download, so a discarded manager and its cache remain
collectible.

Two properties of this hook are less obvious than they look, and each has a
dedicated test:

- *The hook is registered once per class loader, not once per root.* The root is
  recreated if it disappears behind our back (a temp-dir sweeper such as
  `systemd-tmpfiles`, or macOS periodic cleanup). Registering a hook per root
  would reintroduce exactly the accumulation this issue is about, and a `Thread`
  per entry is heavier than the string `DeleteOnExitHook` retained. A
  `shutdownHookAttempted` guard registers once, and the hook reads the current
  root when it runs rather than capturing one.
- *The hook's delete path uses only JDK types.* It runs at JVM exit, when the
  class loader that defined this class may already be closed — which is what
  Maven does to a plugin class realm at the end of a build. A class the hook
  only needs at that point could no longer be resolved, and the hook would die
  with `NoClassDefFoundError` and delete nothing. `FileUtils.deleteQuietly()` is
  therefore replaced by a small `deleteRecursively()` built on `DirectoryStream`
  and `Files.deleteIfExists()`, deleting depth-first and treating symbolic links
  as leaves (`NOFOLLOW_LINKS`) so nothing outside the tree is touched.

**2. Immediate deletion when a file will not be returned**

A `retainTempFile` flag is set only once the file is the one reachable through
the cache. The merged `finally` block deletes the temp file straight away
otherwise — covering `ConnectionException` / `AuthenticationException` (connect
failure), `TransferFailedException` / `ResourceDoesNotExistException` /
`AuthorizationException` (transfer failure), and losing a race to cache the same
URL. Failed downloads therefore contribute nothing at all at shutdown.

**3. New `DefaultDownloadManager.cleanup()` for long-lived JVMs**

Deletes this manager's downloads and empties its cache, so a Maven daemon or
embedded build can release the files without waiting for JVM exit. It is
optional, and it is added on the implementation only — the `DownloadManager`
interface is unchanged, so no existing implementor breaks.

### Cache correctness

`cache.put()` is replaced with a guarded `putIfAbsent`: a concurrent download of
the same URL now returns the file already published in the cache (which callers
may already be reading) and discards its own redundant copy, while a **stale**
cache entry — one whose file has since been deleted from disk — is replaced by
the fresh download instead of being handed back. The previous code could return
a `File` that no longer existed; `shouldDownloadAgainWhenTheCachedFileWasDeleted`
fails without this change.

### Refactor

The separate `try`/`catch` blocks around `wagon.connect()` and `wagon.get()` are
merged into one. A `connected` flag keeps `wagon.disconnect()` limited to the
case where `connect()` actually succeeded, and transfer listeners are now removed
even when connecting failed — they are added before the connect attempt, so
leaving them attached leaked listeners onto a `Wagon` that may be reused.

`addShutdownHook()` catches `SecurityException` alongside `IllegalStateException`,
so a restrictive policy makes cleanup fall back to the OS temp sweeper instead of
throwing an unchecked exception out of `download()`.

## Tests

`DefaultDownloadManagerTest` grows from 20 to 31 tests. The new ones:

- `shouldDownloadIntoTheSharedTempDirectoryInsteadOfRegisteringDeleteOnExit` — the
  download lands under the single shared directory, the structural property that
  keeps shutdown bookkeeping constant
- `shouldDeleteTempFileOnConnectionFailure` — no file is left behind under the
  download directory after a `ConnectionException`
- `shouldDeleteTempFileOnTransferFailure` — uses an EasyMock `Capture` to get the
  exact `File` passed to `wagon.get()` and asserts it no longer exists after a
  `TransferFailedException`
- `shouldDownloadAgainWhenTheCachedFileWasDeleted` — a stale cache entry is
  replaced rather than returned
- `shouldDeleteDownloadedFilesOnCleanup` — `cleanup()` removes the files and the
  directory
- `shouldStillBeUsableAfterCleanup` — the manager recreates its directory and
  keeps working after `cleanup()`
- `shouldNotDeleteTheFilesOfAnotherManagerOnCleanup` — `cleanup()` is isolated
  per instance
- `shouldRegisterAtMostOneShutdownHookHoweverManyDownloadsAndManagers` — 25
  managers, repeated downloads and `cleanup()` calls add no hooks
- `shouldNotRegisterAnotherShutdownHookWhenTheRootIsRemovedBehindOurBack` — 25
  simulated sweeps of the root recreate it and keep downloading, still on one hook
- `shouldDeleteNestedDirectoriesOnCleanupWithoutFollowingSymbolicLinks` — whatever
  a wagon leaves in the directory is removed, and a link's target outside the tree
  survives
- `shouldDeleteTheRootWithoutClassesThatAShutdownHookCouldNoLongerLoad` — loads the
  manager in a class loader where commons-io does not exist and runs the hook's
  body, proving the delete path needs nothing the hook could fail to resolve

The two hook-count tests read a package-private `registeredShutdownHooks()`
counter. Asserting on `java.io.DeleteOnExitHook` or
`java.lang.ApplicationShutdownHooks` directly would need `--add-opens
java.base/java.lang`, which this module does not configure for Surefire, so the
class exposes the count instead.

All 31 `DefaultDownloadManagerTest` tests pass, and no
`maven-shared-io-downloads-*` directory remains after the test JVM exits, which
exercises the shutdown hook end to end.

## Notes for reviewers

- **The hook holds a reference to the class loader that defined this class.** Any
  shutdown hook running library code does; `deleteOnExit()` did not, since it
  retains only strings. In Maven that means one plugin class realm stays reachable
  for the life of the JVM once something downloads. The hook's inherited context
  class loader is cleared, which removes the other reference along that path, but
  the remaining one cannot be avoided while keeping a hook at all. It is one
  reference per class loader instead of one entry per downloaded file, so it is
  still a large net reduction — flagging it because it is a real change in kind,
  not because it is believed to be a problem. Dropping the hook entirely and
  relying on `cleanup()` plus the OS temp sweeper is the alternative, at the cost
  of no longer cleaning up after a plain `mvn` run.
- Downloaded files still occupy disk for the lifetime of the manager — the caller
  reads the returned `File`, so it has to exist. Bounding disk usage (LRU or size
  cap) would be a separate feature.
- `cleanup()` is documented as unsafe to call while a download is in flight on
  another thread, since that download writes into the directory being removed.
- `URLLocation` still calls `deleteOnExit()` per fetched URL. Same pattern,
  different class, and it sits behind the public `tempFileDeleteOnExit`
  constructor flag, so changing it is an API-semantics decision; left out to keep
  this PR to one issue. Happy to open a follow-up.

## Contribution Checklist

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
      (11 new tests. The two hook-count tests and the class-loading test were each
      verified by mutation: restoring the per-root hook registration fails the
      first two, and putting `FileUtils.deleteQuietly()` back in the hook path
      fails the third with the `NoClassDefFoundError` described above.)
- [ X] Run `mvn verify` to make sure basic checks pass.
      (Partially verified locally. Spotless, Checkstyle and RAT all pass —
      `spotless:check` reports 41 files clean with the cache cleared, Checkstyle
      reports 0 violations, RAT 0 unapproved licences — and main and test sources
      compile at `--release 8`. A full `mvn verify` could not run in this
      environment: the enforcer requires Maven 3.9+ and only 3.8.5 is available,
      and Surefire 3.5.6 needs `plexus-utils:1.1`, which is not in the local
      repository and cannot be fetched. Tests were therefore run through a JUnit
      Platform launcher against the same compiled classes. Relying on CI for the
      full lifecycle.)
- [x] I hereby declare this contribution to be licenced under the Apache License Version 2.0, January 2004
