### PR TITLE
fix: remove dead code catch block for ArtifactNotFoundException

### DIFF
--- a/src/main/java/org/apache/maven/shared/io/location/ArtifactLocatorStrategy.java
+++ b/src/main/java/org/apache/maven/shared/io/location/ArtifactLocatorStrategy.java
@@ -23,7 +23,6 @@ import java.util.List;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.factory.ArtifactFactory;
 import org.apache.maven.artifact.repository.ArtifactRepository;
-import org.apache.maven.artifact.resolver.ArtifactNotFoundException;
 import org.apache.maven.artifact.resolver.ArtifactResolutionException;
 import org.apache.maven.artifact.resolver.ArtifactResolver;
 import org.apache.maven.shared.io.logging.MessageHolder;
@@ -159,10 +158,6 @@ public class ArtifactLocatorStrategy implements LocatorStrategy {
                             "Supposedly resolved artifact: " + artifact.getId() + " does not have an associated file.");
                 }
             } catch (ArtifactResolutionException e) {
-                messageHolder.addMessage(
-                        "Failed to resolve artifact: " + artifact.getId() + " for location: " + locationSpecification,
-                        e);
-            } catch (ArtifactNotFoundException e) {
                 messageHolder.addMessage(
                         "Failed to resolve artifact: " + artifact.getId() + " for location: " + locationSpecification,
                         e);


### PR DESCRIPTION
## Description

This PR fixes a dead code issue in `ArtifactLocatorStrategy.java`.

### Problem
The `ArtifactNotFoundException` catch block (lines 165-168) was unreachable because `ArtifactNotFoundException` extends `ArtifactResolutionException`. The first catch block catches all instances, making the second catch block dead code.

### Solution
Removed the dead catch block and the unused import for `ArtifactNotFoundException`.

## Related Issue
Closes #92

## Changes
- `src/main/java/org/apache/maven/shared/io/location/ArtifactLocatorStrategy.java`: Removed dead catch block and unused import