### PR TITLE
Provide safe defaults for temp file prefix/suffix when null and add regression test for issue #95.

### DIFF
--- a/src/main/java/org/apache/maven/shared/io/location/URLLocation.java
+++ b/src/main/java/org/apache/maven/shared/io/location/URLLocation.java
@@ -50,8 +50,8 @@ public class URLLocation extends FileLocation {
         super(specification);
 
         this.url = url;
-        this.tempFilePrefix = tempFilePrefix;
-        this.tempFileSuffix = tempFileSuffix;
+        this.tempFilePrefix = (tempFilePrefix != null) ? tempFilePrefix : "url";
+        this.tempFileSuffix = (tempFileSuffix != null) ? tempFileSuffix : ".tmp";
         this.tempFileDeleteOnExit = tempFileDeleteOnExit;
     }
 

--- a/src/test/java/org/apache/maven/shared/io/location/URLLocationTest.java
+++ b/src/test/java/org/apache/maven/shared/io/location/URLLocationTest.java
@@ -77,4 +77,16 @@ class URLLocationTest {
 
         assertEquals(testStr, new String(buffer, "US-ASCII"));
     }
+
+    @Test
+    void shouldUseDefaultsWhenTempFilePrefixAndSuffixAreNull() throws Exception {
+        File f = Files.createTempFile("url-location.", ".test").toFile();
+        f.deleteOnExit();
+
+        URL url = f.toURL();
+
+        URLLocation location = new URLLocation(url, f.getAbsolutePath(), null, null, true);
+
+        assertNotNull(location.getFile());
+    }
 }


### PR DESCRIPTION
## Summary

This pull request fixes issue #95 by providing safe default values when
`URLLocation` creates a temporary file using `Files.createTempFile(...)`.

Previously, passing `null` as the prefix or suffix resulted in a
`NullPointerException`.

### Changes

- Use `"url"` as the default prefix when the provided prefix is `null`
- Use `".tmp"` as the default suffix when the provided suffix is `null`
- Add a regression test covering this behavior

Fixes #95