### PR TITLE
Fix NPEs in SuffixMapping, SingleTargetMapping, and URLLocation

### DIFF
--- a/src/main/java/org/apache/maven/shared/io/location/URLLocation.java
+++ b/src/main/java/org/apache/maven/shared/io/location/URLLocation.java
@@ -58,7 +58,10 @@ public class URLLocation extends FileLocation {
     /** {@inheritDoc} */
     protected void initFile() throws IOException {
         if (unsafeGetFile() == null) {
-            File tempFile = Files.createTempFile(tempFilePrefix, tempFileSuffix).toFile();
+            String prefix = tempFilePrefix == null ? "url" : tempFilePrefix;
+            String suffix = tempFileSuffix == null ? ".tmp" : tempFileSuffix;
+
+            File tempFile = Files.createTempFile(prefix, suffix).toFile();
 
             if (tempFileDeleteOnExit) {
                 tempFile.deleteOnExit();

--- a/src/main/java/org/apache/maven/shared/io/scan/mapping/SingleTargetMapping.java
+++ b/src/main/java/org/apache/maven/shared/io/scan/mapping/SingleTargetMapping.java
@@ -47,7 +47,7 @@ public class SingleTargetMapping implements SourceMapping {
 
     /** {@inheritDoc} */
     public Set<File> getTargetFiles(File targetDir, String source) throws InclusionScanException {
-        if (!source.endsWith(sourceSuffix)) {
+        if (source == null || sourceSuffix == null || !source.endsWith(sourceSuffix)) {
             return Collections.<File>emptySet();
         }
 

--- a/src/main/java/org/apache/maven/shared/io/scan/mapping/SuffixMapping.java
+++ b/src/main/java/org/apache/maven/shared/io/scan/mapping/SuffixMapping.java
@@ -56,6 +56,10 @@ public final class SuffixMapping implements SourceMapping {
     public Set<File> getTargetFiles(File targetDir, String source) {
         Set<File> targetFiles = new HashSet<>();
 
+        if (source == null || sourceSuffix == null) {
+            return targetFiles;
+        }
+
         if (source.endsWith(sourceSuffix)) {
             String base = source.substring(0, source.length() - sourceSuffix.length());
 

--- a/src/test/java/org/apache/maven/shared/io/location/URLLocationTest.java
+++ b/src/test/java/org/apache/maven/shared/io/location/URLLocationTest.java
@@ -77,4 +77,16 @@ class URLLocationTest {
 
         assertEquals(testStr, new String(buffer, "US-ASCII"));
     }
+
+    @Test
+    void shouldNotThrowNpeWhenTempFilePrefixAndSuffixAreNull() throws Exception {
+        File f = Files.createTempFile("url-location.", ".test").toFile();
+        f.deleteOnExit();
+
+        URL url = f.toURL();
+
+        URLLocation location = new URLLocation(url, f.getAbsolutePath(), null, null, true);
+
+        assertNotNull(location.getFile());
+    }
 }

--- a/src/test/java/org/apache/maven/shared/io/scan/mapping/SuffixMappingTest.java
+++ b/src/test/java/org/apache/maven/shared/io/scan/mapping/SuffixMappingTest.java
@@ -98,6 +98,30 @@ class SuffixMappingTest {
     }
 
     @Test
+    void shouldReturnNoTargetFilesWhenSourceIsNull() throws Exception {
+        File basedir = new File(".");
+
+        SuffixMapping mapping = new SuffixMapping(".java", ".class");
+
+        Set<File> results = mapping.getTargetFiles(basedir, null);
+
+        assertTrue(results.isEmpty(), "Returned wrong number of target files.");
+    }
+
+    @Test
+    void shouldReturnNoTargetFilesWhenSourceSuffixIsNull() throws Exception {
+        String base = "path/to/file";
+
+        File basedir = new File(".");
+
+        SuffixMapping mapping = new SuffixMapping(null, ".class");
+
+        Set<File> results = mapping.getTargetFiles(basedir, base + ".java");
+
+        assertTrue(results.isEmpty(), "Returned wrong number of target files.");
+    }
+
+    @Test
     void singleTargetMapper() throws Exception {
         String base = "path/to/file";
 
@@ -112,5 +136,29 @@ class SuffixMappingTest {
         results = mapping.getTargetFiles(basedir, base + ".cs");
 
         assertEquals(1, results.size());
+    }
+
+    @Test
+    void singleTargetMapperShouldReturnNoTargetFilesWhenSourceIsNull() throws Exception {
+        File basedir = new File("target/");
+
+        SingleTargetMapping mapping = new SingleTargetMapping(".cs", "/foo");
+
+        Set<File> results = mapping.getTargetFiles(basedir, null);
+
+        assertTrue(results.isEmpty());
+    }
+
+    @Test
+    void singleTargetMapperShouldReturnNoTargetFilesWhenSourceSuffixIsNull() throws Exception {
+        String base = "path/to/file";
+
+        File basedir = new File("target/");
+
+        SingleTargetMapping mapping = new SingleTargetMapping(null, "/foo");
+
+        Set<File> results = mapping.getTargetFiles(basedir, base + ".cs");
+
+        assertTrue(results.isEmpty());
     }
 }


### PR DESCRIPTION
## What

Fixes three related NullPointerException bugs:

- `SuffixMapping#getTargetFiles` threw NPE from `source.endsWith(sourceSuffix)` when either argument was `null`.
- `SingleTargetMapping#getTargetFiles` had the same `endsWith(null)` NPE pattern.
- `URLLocation#initFile` threw NPE from `Files.createTempFile(tempFilePrefix, tempFileSuffix)` when the prefix/suffix constructor args were `null` (allowed by the public constructor).

## Fix

- `SuffixMapping` / `SingleTargetMapping`: guard with a null check before calling `endsWith`, returning an empty result set (no match) instead of throwing.
- `URLLocation`: fall back to default values (`"url"` / `".tmp"`) when the prefix/suffix are null, consistent with how the constructor already allows them to be null.

## Testing

Added regression tests for each case following the existing test style in `SuffixMappingTest` and `URLLocationTest`.

Fixes #93
Fixes #94
Fixes #95