### PR TITLE
Handle null temp file prefix/suffix in URLLocation

### DIFF
--- a/src/main/java/org/apache/maven/shared/io/location/URLLocation.java
+++ b/src/main/java/org/apache/maven/shared/io/location/URLLocation.java
@@ -58,7 +58,10 @@ public class URLLocation extends FileLocation {
     /** {@inheritDoc} */
     protected void initFile() throws IOException {
         if (unsafeGetFile() == null) {
-            File tempFile = Files.createTempFile(tempFilePrefix, tempFileSuffix).toFile();
+            String prefix = (tempFilePrefix == null) ? "url" : tempFilePrefix;
+            String suffix = (tempFileSuffix == null) ? ".tmp" : tempFileSuffix;
+
+            File tempFile = Files.createTempFile(prefix, suffix).toFile();
 
             if (tempFileDeleteOnExit) {
                 tempFile.deleteOnExit();

--- a/src/test/java/org/apache/maven/shared/io/location/URLLocationTest.java
+++ b/src/test/java/org/apache/maven/shared/io/location/URLLocationTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class URLLocationTest {
 
@@ -76,5 +77,20 @@ class URLLocationTest {
         assertEquals(testStr.length(), read);
 
         assertEquals(testStr, new String(buffer, "US-ASCII"));
+    }
+
+    @Test
+    void shouldHandleNullTempFilePrefixAndSuffix() throws Exception {
+        File f = Files.createTempFile("url-location.", ".test").toFile();
+        f.deleteOnExit();
+
+        URL url = f.toURL();
+
+        URLLocation location = new URLLocation(url, f.getAbsolutePath(), null, null, true);
+
+        location.open();
+
+        assertNotNull(location.getFile());
+        assertTrue(location.getFile().exists());
     }
 }


### PR DESCRIPTION
Fixed NPE when URLLocation gets null tempFilePrefix or tempFileSuffix by using safe defaults (url and .tmp) before createTempFile. Added regression test to ensure null prefix and suffix do not crash and still write a temp file.

if this saved you time, you can send a tip here: 69cT26eTDKnqq3wfmDAau7mVBrN8jVTnVbMaSU4DVfxB