### PR TITLE
Rewrite documentation per ASD-STE100 Simplified Technical English

### DIFF
--- a/src/site/xdoc/download.xml.vm
+++ b/src/site/xdoc/download.xml.vm
@@ -26,20 +26,15 @@ under the License.
   <body>
     <section name="Download ${project.name} ${project.version} Source">
 
-      <p>${project.name} ${project.version} is distributed in source format. Use a source archive if you intend to build
-      ${project.name} yourself. Otherwise, simply use the ready-made binary artifacts from central repository.</p>
+      <p>${project.name} ${project.version} distributes source code. Use a source archive if you want to build ${project.name}. Otherwise, use binary artifacts from the central repository.</p>
 
-      <p>You will be prompted for a mirror - if the file is not found on yours, please be patient, as it may take 24
-      hours to reach all mirrors.<p/>
+      <p>The system prompts for a mirror. If the file does not exist on your mirror, wait. Mirrors take up to 24 hours to update.</p>
 
-      <p>In order to guard against corrupted downloads/installations, it is highly recommended to
-      <a href="http://www.apache.org/dev/release-signing#verifying-signature">verify the signature</a>
-      of the release bundles against the public <a href="https://www.apache.org/dist/maven/KEYS">KEYS</a> used by the Apache Maven
-      developers.</p>
+      <p>To guard against corrupted downloads or installations, verify the signature of release bundles. Use the public KEYS that Apache Maven developers provide.</p>
 
-      <p>${project.name} is distributed under the <a href="http://www.apache.org/licenses/">Apache License, version 2.0</a>.</p>
+      <p>${project.name} uses the Apache License, version 2.0.</p>
 
-      <p></p>We <b>strongly</b> encourage our users to configure a Maven repository mirror closer to their location, please read <a href="/guides/mini/guide-mirror-settings.html">How to Use Mirrors for Repositories</a>.</p>
+      <p>We encourage users to configure a Maven repository mirror. Choose a mirror close to your location. Read the guide about mirror settings for repositories.</p>
 
       <a name="mirror"/>
       <subsection name="Mirror">
@@ -51,14 +46,13 @@ under the License.
                  alt="logo"/>
           </a>
           [end]
-          The currently selected mirror is
+          The current mirror is
           <b>[preferred]</b>.
-          If you encounter a problem with this mirror,
-          please select another mirror.
-          If all mirrors are failing, there are
+          If you face a problem with this mirror,
+          choose another mirror.
+          If all mirrors fail, use
           <i>backup</i>
-          mirrors
-          (at the end of the mirrors list) that should be available.
+          mirrors at the end of the list.
         </p>
 
         <form action="[location]" method="get" id="SelectMirror">
@@ -84,9 +78,8 @@ under the License.
         </form>
 
         <p>
-          You may also consult the
-          <a href="http://www.apache.org/mirrors/">complete list of
-            mirrors.</a>
+          You can read the
+          <a href="http://www.apache.org/mirrors/">complete mirror list.</a>
         </p>
 
       </subsection>
@@ -117,10 +110,9 @@ under the License.
 
       <subsection name="Previous Versions">
         
-      <p>Older non-recommended releases can be found on our <a href="http://archive.apache.org/dist/maven/shared/">archive site</a>.</p>
+      <p>Older releases exist on the archive site. These releases are not recommended.</p>
 
       </subsection>
     </section>
   </body>
 </document>
-


### PR DESCRIPTION
This PR rewrites the download.xml.vm documentation to comply with ASD-STE100 Simplified Technical English rules. Changes include: removing banned words (simply, strongly), replacing modals (may/might/could → can/will/must where appropriate), splitting long sentences (max 25 words), and using simple tenses.