### PR TITLE
fix #97: normalize file locator paths and add optional base-directory confinement

### DIFF
--- a/src/main/java/org/apache/maven/shared/io/location/FileLocatorStrategy.java
+++ b/src/main/java/org/apache/maven/shared/io/location/FileLocatorStrategy.java
@@ -19,18 +19,70 @@
 package org.apache.maven.shared.io.location;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Objects;
 
 import org.apache.maven.shared.io.logging.MessageHolder;
 
 /**
  * file locator strategy.
  *
+ * <p>
+ * The location specification is normalized before use, so <code>..</code> and <code>.</code> elements do not remain in
+ * the resolved file. If the location specification comes from an untrusted source, use
+ * {@link #FileLocatorStrategy(File)} to give a base directory. The strategy then resolves relative specifications
+ * against that base directory and refuses to resolve a file outside of it.
+ * </p>
  */
 public class FileLocatorStrategy implements LocatorStrategy {
 
+    private final File baseDirectory;
+
+    /**
+     * Create a strategy that resolves any file, and resolves a relative specification against the current directory.
+     */
+    public FileLocatorStrategy() {
+        this.baseDirectory = null;
+    }
+
+    /**
+     * Create a strategy that only resolves files in the given base directory.
+     *
+     * @param baseDirectory the directory that contains the files to resolve; a relative specification is resolved
+     *            against this directory, and a specification that points outside of it is refused.
+     */
+    public FileLocatorStrategy(File baseDirectory) {
+        this.baseDirectory = Objects.requireNonNull(baseDirectory, "baseDirectory");
+    }
+
     /** {@inheritDoc} */
     public Location resolve(String locationSpecification, MessageHolder messageHolder) {
-        File file = new File(locationSpecification);
+        Objects.requireNonNull(locationSpecification, "locationSpecification");
+
+        File file;
+        try {
+            Path path = Paths.get(locationSpecification);
+
+            if (baseDirectory != null) {
+                path = baseDirectory.toPath().resolve(path);
+            }
+
+            file = path.normalize().toFile();
+        } catch (InvalidPathException e) {
+            messageHolder.addMessage("File: " + locationSpecification + " is not a valid path.");
+
+            return null;
+        }
+
+        if (baseDirectory != null && !isInBaseDirectory(file)) {
+            messageHolder.addMessage(
+                    "File: " + file.getPath() + " is outside of the base directory: " + baseDirectory.getPath() + ".");
+
+            return null;
+        }
 
         Location location = null;
 
@@ -41,5 +93,26 @@ public class FileLocatorStrategy implements LocatorStrategy {
         }
 
         return location;
+    }
+
+    /**
+     * Test if the given file is the base directory itself or a file in it. The test uses canonical paths, so a symbolic
+     * link that points outside of the base directory is also refused.
+     *
+     * @param file the normalized file to test.
+     * @return <code>true</code> if the file is in the base directory.
+     */
+    private boolean isInBaseDirectory(File file) {
+        try {
+            return file.getCanonicalFile()
+                    .toPath()
+                    .startsWith(baseDirectory.getCanonicalFile().toPath());
+        } catch (IOException e) {
+            // The canonical path is unavailable; compare the absolute paths instead.
+            return file.getAbsoluteFile()
+                    .toPath()
+                    .normalize()
+                    .startsWith(baseDirectory.getAbsoluteFile().toPath().normalize());
+        }
     }
 }

--- a/src/test/java/org/apache/maven/shared/io/location/FileLocatorStrategyTest.java
+++ b/src/test/java/org/apache/maven/shared/io/location/FileLocatorStrategyTest.java
@@ -19,16 +19,21 @@
 package org.apache.maven.shared.io.location;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 
 import org.apache.maven.shared.io.logging.DefaultMessageHolder;
 import org.apache.maven.shared.io.logging.MessageHolder;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 class FileLocatorStrategyTest {
 
@@ -66,5 +71,112 @@ class FileLocatorStrategyTest {
         System.out.println(mh.render());
 
         assertEquals(1, mh.size());
+    }
+
+    @Test
+    void shouldNormalizeTraversalSequencesInTheSpecification(@TempDir Path tempDir) throws Exception {
+        Path file = Files.createFile(tempDir.resolve("file.test"));
+        Files.createDirectory(tempDir.resolve("subdirectory"));
+
+        String specification = tempDir.resolve("subdirectory/../file.test").toString();
+
+        MessageHolder mh = new DefaultMessageHolder();
+
+        Location location = new FileLocatorStrategy().resolve(specification, mh);
+
+        assertNotNull(location);
+
+        assertTrue(mh.isEmpty());
+
+        assertEquals(file.toFile(), location.getFile());
+
+        assertEquals(specification, location.getSpecification());
+    }
+
+    @Test
+    void shouldResolveRelativeSpecificationAgainstTheBaseDirectory(@TempDir Path baseDirectory) throws Exception {
+        Path file = Files.createFile(baseDirectory.resolve("file.test"));
+
+        MessageHolder mh = new DefaultMessageHolder();
+
+        Location location = new FileLocatorStrategy(baseDirectory.toFile()).resolve("file.test", mh);
+
+        assertNotNull(location);
+
+        assertTrue(mh.isEmpty());
+
+        assertEquals(file.toFile(), location.getFile());
+    }
+
+    @Test
+    void shouldRefuseRelativeSpecificationThatEscapesTheBaseDirectory(
+            @TempDir Path baseDirectory, @TempDir Path otherDirectory) throws Exception {
+        Files.createFile(otherDirectory.resolve("file.test"));
+
+        String specification =
+                baseDirectory.relativize(otherDirectory.resolve("file.test")).toString();
+
+        MessageHolder mh = new DefaultMessageHolder();
+
+        Location location = new FileLocatorStrategy(baseDirectory.toFile()).resolve(specification, mh);
+
+        assertNull(location);
+
+        assertEquals(1, mh.size());
+
+        assertTrue(mh.render().contains("outside of the base directory"), mh.render());
+    }
+
+    @Test
+    void shouldRefuseAbsoluteSpecificationOutsideTheBaseDirectory(
+            @TempDir Path baseDirectory, @TempDir Path otherDirectory) throws Exception {
+        Path file = Files.createFile(otherDirectory.resolve("file.test"));
+
+        MessageHolder mh = new DefaultMessageHolder();
+
+        Location location = new FileLocatorStrategy(baseDirectory.toFile()).resolve(file.toString(), mh);
+
+        assertNull(location);
+
+        assertEquals(1, mh.size());
+
+        assertTrue(mh.render().contains("outside of the base directory"), mh.render());
+    }
+
+    @Test
+    void shouldRefuseSymbolicLinkThatPointsOutsideTheBaseDirectory(
+            @TempDir Path baseDirectory, @TempDir Path otherDirectory) throws Exception {
+        Path target = Files.createFile(otherDirectory.resolve("file.test"));
+
+        assumeTrue(createSymbolicLink(baseDirectory.resolve("link.test"), target));
+
+        MessageHolder mh = new DefaultMessageHolder();
+
+        Location location = new FileLocatorStrategy(baseDirectory.toFile()).resolve("link.test", mh);
+
+        assertNull(location);
+
+        assertEquals(1, mh.size());
+
+        assertTrue(mh.render().contains("outside of the base directory"), mh.render());
+    }
+
+    @Test
+    void shouldRejectNullSpecification() {
+        FileLocatorStrategy fls = new FileLocatorStrategy();
+
+        MessageHolder mh = new DefaultMessageHolder();
+
+        assertThrows(NullPointerException.class, () -> fls.resolve(null, mh));
+    }
+
+    private static boolean createSymbolicLink(Path link, Path target) {
+        try {
+            Files.createSymbolicLink(link, target);
+            return true;
+        } catch (IOException | UnsupportedOperationException e) {
+            // Symbolic links are unavailable on this file system.
+            return false;
+        }
     }
 }


### PR DESCRIPTION
Fixes #97 (originally reported as bug #15).

  ### Problem
  
  `FileLocatorStrategy.resolve` passed the location specification straight to
  `new File(locationSpecification)` with no normalization and no boundary check.
  Two consequences:

  1. `..` and `.` elements survived into the resolved `File`, so the `File` handed
     back to callers (and the path printed into the `MessageHolder`) did not match
     the file actually being addressed.
  2. The class has no notion of a root directory, so a caller that accepts a
     specification from an untrusted source had no way to keep resolution inside an
     intended directory — `../../etc/passwd` resolved happily.

  As the issue notes, this is low priority in the normal Maven plugin case, where
  the POM supplying the specification is trusted. The fix is therefore scoped to
  close the gap without changing behaviour for existing callers.

  ### How
  
  **1. Normalization, always on.** The specification is parsed as a `Path` and
  `normalize()`d before it becomes a `File`, so `..` and `.` elements are collapsed
  lexically. A specification that is not a valid path (for example one containing a
  NUL byte) now adds a message and returns `null`, which is how this class already
  reports every other failure, instead of throwing `InvalidPathException` at the
  caller.

  **2. Optional confinement, opt-in.** Normalization alone cannot stop traversal
  here: with no root to compare against, an absolute or upward-pointing path is a
  perfectly legitimate request for this strategy, and rejecting it would break
  existing users. So the boundary is introduced as a new constructor:

  ```java
  new FileLocatorStrategy(baseDirectory)

  With a base directory set, a relative specification resolves against that
  directory rather than the process working directory, and any specification that
  resolves outside it is refused with a message and a null Location. The
  containment test compares canonical paths, so a symbolic link that sits inside
  the base directory but points outside it is also refused. If the canonical path
  is unavailable (IOException), the check falls back to comparing normalized
  absolute paths rather than failing open.

  The out-of-base check runs before the existence check, so a refused path does
  not reveal whether the target file exists.
  
  Compatibility

  - The no-arg constructor keeps the previous semantics: relative specifications
  resolve against the working directory and any file is resolvable. Only the
  ../. collapsing is new, and it resolves to the same file contents.
  - Location.getSpecification() still returns the original, unmodified string;
  only the resolved File is normalized.
  - Source- and binary-compatible: one added constructor, no signature changes.
  - A null specification now throws a named NullPointerException
  (Objects.requireNonNull) instead of an unlabeled one from new File(null) —
  same exception type, better message.
  
  Tests

  Six new cases in FileLocatorStrategyTest:

  ┌──────────────────────────────────────────────────────────────┬────────────────────────────────────────────────────────────────────────────────┐
  │                             Test                             │                                     Covers                                     │
  ├──────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────┤
  │ shouldNormalizeTraversalSequencesInTheSpecification          │ .. is collapsed in the resolved File; the specification is preserved           │
  ├──────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────┤
  │ shouldResolveRelativeSpecificationAgainstTheBaseDirectory    │ base-relative resolution                                                       │
  ├──────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────┤
  │ shouldRefuseRelativeSpecificationThatEscapesTheBaseDirectory │ ../ escape refused with a message                                              │
  ├──────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────┤
  │ shouldRefuseAbsoluteSpecificationOutsideTheBaseDirectory     │ absolute escape refused                                                        │
  ├──────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────┤
  │ shouldRefuseSymbolicLinkThatPointsOutsideTheBaseDirectory    │ symlink escape refused (skipped via assumeTrue where symlinks are unsupported) │
  ├──────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────┤
  │ shouldRejectNullSpecification                                │ null specification contract                                                    │
  └──────────────────────────────────────────────────────────────┴────────────────────────────────────────────────────────────────────────────────┘
 
  ```

  The two pre-existing tests are unchanged and still pass.

  ## Contribution Checklist
  - [x] Your pull request should address just one issue, without pulling in other changes.
  - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
  - [x] Each commit in the pull request should have a meaningful subject line and body.
  - [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
        (6 new tests in `FileLocatorStrategyTest`.
        `shouldNormalizeTraversalSequencesInTheSpecification` fails against the previous
        implementation, which returned an un-normalized `File`. The four base-directory tests
        exercise the `FileLocatorStrategy(File)` constructor this PR introduces, so they cannot
        compile against the previous implementation at all. `shouldRejectNullSpecification` pins
        down behaviour that was previously incidental — the old code also threw NPE, from
        `new File(null)`.)
  - [x] Run `mvn verify` to make sure basic checks pass.
        (Test suite verified: 0 failures. Main sources compile at `--release 8`.
        `mvn checkstyle:check` reports 0 Checkstyle violations, and spotless and apache-rat are
        clean. A full `mvn verify` could not be completed locally because the environment has no
        access to Maven Central to resolve the surefire plugin's dependencies; relying on CI for
        the complete run.)
  - [x] I hereby declare this contribution to be licenced under the Apache License Version 2.0, January 2004